### PR TITLE
Bug: Finders key for WSL

### DIFF
--- a/ScraperFC/shared_functions.py
+++ b/ScraperFC/shared_functions.py
@@ -166,7 +166,7 @@ sources = {
         'WSL': {
             'first valid year': 2017,
             'url': 'https://fbref.com/en/comps/189/history/Womens-Super-League-Seasons',
-            'finder': ['Womens-Super-League-1'],
+            'finder': ['Womens-Super-League'],
         },
         'D1 Feminine': {
             'first valid year': 2018,


### PR DESCRIPTION
The "-1" in the finder key for WSL needs to be removed in order to get url matches. Verified below.

![image](https://user-images.githubusercontent.com/24653983/224853182-9aafe9c2-0a73-4991-897c-56d9a6a3aa75.png)
