### PR TITLE
Fix understat loader issue for newest selenium version

### DIFF
--- a/ScraperFC/Understat.py
+++ b/ScraperFC/Understat.py
@@ -5,6 +5,7 @@ import pandas as pd
 from ScraperFC.shared_functions import check_season
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
 from webdriver_manager.chrome import ChromeDriverManager
@@ -23,8 +24,8 @@ class Understat:
         options.add_argument("window-size=1400,600")
         prefs = {'profile.managed_default_content_settings.images': 2} # don't load images
         options.add_experimental_option('prefs', prefs)
-        self.driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
-        
+        service = Service(ChromeDriverManager().install())
+        self.driver = webdriver.Chrome(options=options, service=service)       
         
     ####################################################################################################################
     def close(self):


### PR DESCRIPTION
Understat scraper crashes due to `WebDriver` constructor update in newest selenium version ([4.10.0](https://pypi.org/project/selenium/) -- see [code changes](https://github.com/SeleniumHQ/selenium/commit/9f5801c82fb3be3d5850707c46c3f8176e3ccd8e), related [SO post](https://stackoverflow.com/questions/76428561/typeerror-webdriver-init-got-multiple-values-for-argument-options)).

```python
import ScraperFC as sfc

understat = sfc.Understat()

understat.get_team_links(2023, 'EPL')
```

<img width="690" alt="Screenshot 2023-07-03 at 15 14 22" src="https://github.com/oseymour/ScraperFC/assets/6474359/db1fb0a6-efec-4272-8383-577be59c6962">