### PR TITLE
change the .split() parameter string

### DIFF
--- a/ScraperFC/Sofascore.py
+++ b/ScraperFC/Sofascore.py
@@ -81,7 +81,7 @@ class Sofascore:
         """
         # this can also be found in the 'id' key of the dict returned from 
         # get_match_data(), if the format of the match url ever changes
-        match_id = match_url.split('#')[-1]
+        match_id = match_url.split(':')[-1]
         return match_id
     
     ############################################################################


### PR DESCRIPTION
- [x] Change the .split() function inside get_match_url because Sofascore change the structure of their urls to something like this: https://www.sofascore.com/empoli-milan/Rdbsfeb#id:11407516 

Example:
![image](https://github.com/oseymour/ScraperFC/assets/101477588/8c25284a-a71f-496b-ae52-20cfbf985589)
