### PR TITLE
Add Dutch Eredivisie to Sofascore

### DIFF
--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -25,6 +25,7 @@ comps = {
     'Champions League': 7, 'Europa League': 679, 'Europa Conference League': 17015,
     # European domestic leagues
     'EPL': 17, 'La Liga': 8, 'Bundesliga': 35, 'Serie A': 23, 'Ligue 1': 34, 'Turkish Super Lig': 52,
+    'Eredivisie': 37,
     # South America
     'Argentina Liga Profesional': 155, 'Argentina Copa de la Liga Profesional': 13475,
     'Liga 1 Peru': 406, "Copa Libertadores": 384,


### PR DESCRIPTION
Added Dutch Eredivisie as a new league to Sofascore https://www.sofascore.com/tournament/football/netherlands/eredivisie/37.