### PR TITLE
Single comp mapping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,5 @@ repos:
   hooks:
     - id: mypy
       args: ["./src", --ignore-missing-imports, --disallow-untyped-defs]
-      additional_dependencies: [types-requests]
+      additional_dependencies: [types-requests, types-pyyaml]
       pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # -- Metadata --------------------------------------------------------------------------------------
 name = "ScraperFC"
-version = "3.4.0"
+version = "4.0.0"
 description = "Package for scraping soccer data from a variety of sources."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,37 +38,39 @@ dependencies = [
     "tqdm>=4.67.1",
 ]
 
-[dependency-groups]
-dev = [
-    # General
-    "marimo>=0.14.16",
-    "tox>=4.24.1",
-    # Test
+# LEAVE AS OPTIONAL DEPENDENCIES, NOT DEPENDENCY GROUPS
+# readthedocs needs docs to be optional dependency group, so just leave the others as them also
+[project.optional-dependencies]
+test = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
-    # Lint
-    "ruff>=0.11.10",
-    # Docs
+]
+docs = [
     "furo>=2024.8.6",
     "myst-nb>=1.1.2",
     "sphinx>=7.4.7",
-    # Build
+]
+build = [
     "build>=1.2.2.post1",
     "setuptools>=75.8.0",
     "wheel>=0.45.1",
-    # Publish
-    "publish>=0.3.6",
-    # Typecheck
+]
+publish = ["publish>=0.3.6",]
+dev = [
+    "marimo>=0.14.16",
+    "tox>=4.24.1",
+]
+typecheck = [
     "pandas-stubs>=2.2.2.240807",
     "types-beautifulsoup4>=4.12.0.20241020",
     "types-openpyxl>=3.1.5.20241225",
     "types-python-dateutil>=2.9.0.20241206",
     "types-requests>=2.32.0.20241016",
     "types-tqdm>=4.67.0.20241221",
-    "ty>=0.0.1a17",
-    "mypy>=1.14.1",
     "types-pyyaml>=6.0.12.20250516",
+    "mypy>=1.14.1",
 ]
+lint = ["ruff>=0.11.10",]
 
 [project.urls]
 repository = "https://github.com/oseymour/ScraperFC/"
@@ -109,67 +111,71 @@ disallow_untyped_defs = true
 
 # -- Tox  ------------------------------------------------------------------------------------------
 [tool.tox]
+# DO NOT put `--active` in `uv run` commands. GitHub Actions fail with this option.
 legacy_tox_ini = """
     [tox]
     isolated_build = true
-    envlist = py39, py310, py311, py312
+    envlist = py39, py310, py311, py312, py313
 
     [testenv]
-    usedevelop = True
-    extras = dev
+    usedevelop = true
+    extras = test
     allowlist_externals = uv, sphinx-build
     install_command = uv pip install
 
     [testenv:test-all]
     commands = 
         python -m pip list
-        uv run --active pytest ./test/ --cov ScraperFC
+        uv run pytest ./test/ --cov ScraperFC
 
     [testenv:test-capology]
     commands = 
         pip list
-        uv run --active pytest ./test/test_capology.py --cov ScraperFC -s
+        uv run pytest ./test/test_capology.py --cov ScraperFC -s
 
     [testenv:test-clubelo]
     commands = 
         pip list
-        uv run --active pytest ./test/test_clubelo.py --cov ScraperFC -s
+        uv run pytest ./test/test_clubelo.py --cov ScraperFC -s
 
     [testenv:test-fbref]
     commands = 
         pip list
-        uv run --active pytest ./test/test_fbref.py --cov ScraperFC -s
+        uv run pytest ./test/test_fbref.py --cov ScraperFC -s
 
     [testenv:test-sofascore]
     commands = 
         pip list
-        uv run --active pytest ./test/test_sofascore.py --cov ScraperFC -s
+        uv run pytest ./test/test_sofascore.py --cov ScraperFC -s
 
     [testenv:test-transfermarkt]
     commands = 
         pip list
-        uv run --active pytest ./test/test_transfermarkt.py --cov ScraperFC -s
+        uv run pytest ./test/test_transfermarkt.py --cov ScraperFC -s
 
     [testenv:test-understat]
     commands = 
         pip list
-        uv run --active pytest ./test/test_understat.py --cov ScraperFC -s
+        uv run pytest ./test/test_understat.py --cov ScraperFC -s
 
     [testenv:docs]
-    extras = dev
-    commands = uv run --active sphinx-build -nWEa --keep-going -b html ./docs/source/ ./docs/build/
+    extras = docs
+    commands = uv run sphinx-build -nWEa --keep-going -b html ./docs/source/ ./docs/build/
 
     [testenv:build]
     skip_install = true
-    commands = python -m build
+    extras = build
+    commands = uv build
 
     [testenv:lint]
+    extras = lint
     commands = 
-        uv run --active ruff check --select W291 --fix  # fix trailing whitespace
-        uv run --active ruff check --select W292 --fix  # fix missing new line at end of file
-        uv run --active ruff check --select W293 --fix --unsafe-fixes  # fix blank line with whitespace
-        uv run --active ruff check
+        uv run ruff check --select W291 --fix  # fix trailing whitespace
+        uv run ruff check --select W292 --fix  # fix missing new line at end of file
+        uv run ruff check --select W293 --fix --unsafe-fixes  # fix blank line with whitespace
+        uv run ruff check
 
     [testenv:typecheck]
-    commands = uv run --active mypy ./src
+    extras = typecheck
+    commands = uv run mypy ./src
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
     "lxml>=5.3.0",
     "numpy>=2.0.2",
     "pandas>=2.2.3",
+    "pyyaml>=6.0.2",
     "requests>=2.32.3",
+    "rootutils>=1.0.7",
     "selenium>=4.28.1",
     "tqdm>=4.67.1",
 ]
@@ -65,6 +67,7 @@ dev = [
     "types-tqdm>=4.67.0.20241221",
     "ty>=0.0.1a17",
     "mypy>=1.14.1",
+    "types-pyyaml>=6.0.12.20250516",
 ]
 
 [project.urls]
@@ -120,41 +123,41 @@ legacy_tox_ini = """
     [testenv:test-all]
     commands = 
         python -m pip list
-        uv run pytest ./test/ --cov ScraperFC
+        uv run --active pytest ./test/ --cov ScraperFC
 
     [testenv:test-capology]
     commands = 
         pip list
-        uv run pytest ./test/test_capology.py --cov ScraperFC
+        uv run --active pytest ./test/test_capology.py --cov ScraperFC
 
     [testenv:test-clubelo]
     commands = 
         pip list
-        uv run pytest ./test/test_clubelo.py --cov ScraperFC
+        uv run --active pytest ./test/test_clubelo.py --cov ScraperFC
 
     [testenv:test-fbref]
     commands = 
         pip list
-        uv run pytest ./test/test_fbref.py --cov ScraperFC
+        uv run --active pytest ./test/test_fbref.py --cov ScraperFC
 
     [testenv:test-sofascore]
     commands = 
         pip list
-        uv run pytest ./test/test_sofascore.py --cov ScraperFC
+        uv run --active pytest ./test/test_sofascore.py --cov ScraperFC
 
     [testenv:test-transfermarkt]
     commands = 
         pip list
-        uv run pytest ./test/test_transfermarkt.py --cov ScraperFC
+        uv run --active pytest ./test/test_transfermarkt.py --cov ScraperFC
 
     [testenv:test-understat]
     commands = 
         pip list
-        uv run pytest ./test/test_understat.py --cov ScraperFC
+        uv run --active pytest ./test/test_understat.py --cov ScraperFC
 
     [testenv:docs]
     extras = dev
-    commands = uv run sphinx-build -nWEa --keep-going -b html ./docs/source/ ./docs/build/
+    commands = uv run --active sphinx-build -nWEa --keep-going -b html ./docs/source/ ./docs/build/
 
     [testenv:build]
     skip_install = true
@@ -162,11 +165,11 @@ legacy_tox_ini = """
 
     [testenv:lint]
     commands = 
-        uv run ruff check --select W291 --fix  # fix trailing whitespace
-        uv run ruff check --select W292 --fix  # fix missing new line at end of file
-        uv run ruff check --select W293 --fix --unsafe-fixes  # fix blank line with whitespace
-        uv run ruff check
+        uv run --active ruff check --select W291 --fix  # fix trailing whitespace
+        uv run --active ruff check --select W292 --fix  # fix missing new line at end of file
+        uv run --active ruff check --select W293 --fix --unsafe-fixes  # fix blank line with whitespace
+        uv run --active ruff check
 
     [testenv:typecheck]
-    commands = uv run mypy ./src
+    commands = uv run --active mypy ./src
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,32 +128,32 @@ legacy_tox_ini = """
     [testenv:test-capology]
     commands = 
         pip list
-        uv run --active pytest ./test/test_capology.py --cov ScraperFC
+        uv run --active pytest ./test/test_capology.py --cov ScraperFC -s
 
     [testenv:test-clubelo]
     commands = 
         pip list
-        uv run --active pytest ./test/test_clubelo.py --cov ScraperFC
+        uv run --active pytest ./test/test_clubelo.py --cov ScraperFC -s
 
     [testenv:test-fbref]
     commands = 
         pip list
-        uv run --active pytest ./test/test_fbref.py --cov ScraperFC
+        uv run --active pytest ./test/test_fbref.py --cov ScraperFC -s
 
     [testenv:test-sofascore]
     commands = 
         pip list
-        uv run --active pytest ./test/test_sofascore.py --cov ScraperFC
+        uv run --active pytest ./test/test_sofascore.py --cov ScraperFC -s
 
     [testenv:test-transfermarkt]
     commands = 
         pip list
-        uv run --active pytest ./test/test_transfermarkt.py --cov ScraperFC
+        uv run --active pytest ./test/test_transfermarkt.py --cov ScraperFC -s
 
     [testenv:test-understat]
     commands = 
         pip list
-        uv run --active pytest ./test/test_understat.py --cov ScraperFC
+        uv run --active pytest ./test/test_understat.py --cov ScraperFC -s
 
     [testenv:docs]
     extras = dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # -- Metadata --------------------------------------------------------------------------------------
 name = "ScraperFC"
-version = "3.3.0"
+version = "3.4.0"
 description = "Package for scraping soccer data from a variety of sources."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/ScraperFC/capology.py
+++ b/src/ScraperFC/capology.py
@@ -12,9 +12,9 @@ from typing import Sequence
 
 from ScraperFC.scraperfc_exceptions import InvalidCurrencyException, InvalidLeagueException, \
     InvalidYearException
-from ScraperFC.utils import load_comps
+from ScraperFC.utils import get_module_comps
 
-comps = load_comps()
+comps = get_module_comps("Capology")
 
 class Capology():
 

--- a/src/ScraperFC/capology.py
+++ b/src/ScraperFC/capology.py
@@ -7,29 +7,14 @@ from selenium.common.exceptions import StaleElementReferenceException
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
-from ScraperFC.scraperfc_exceptions import InvalidCurrencyException, InvalidLeagueException, \
-    InvalidYearException
 from io import StringIO
 from typing import Sequence
 
-comps = {
-    "Bundesliga":  {'url': 'de/1-bundesliga'},
-    "2.Bundesliga":  {'url': 'de/2-bundesliga'},
-    "EPL":  {'url': 'uk/premier-league'},
-    "EFL Championship":  {'url': 'uk/championship'},
-    "Serie A":  {'url': 'it/serie-a'},
-    "Serie B":  {'url': 'it/serie-b'},
-    "La Liga":  {'url': 'es/la-liga'},
-    "La Liga 2":  {'url': 'es/la-liga-2'},
-    "Ligue 1":  {'url': 'fr/ligue-1'},
-    "Ligue 2":  {'url': 'fr/ligue-2'},
-    "Eredivisie":  {'url': 'ne/eredivisie'},
-    "Primeira Liga":  {'url': 'pt/primeira-liga'},
-    "Scottish PL":  {'url': 'uk/scottish-premiership'},
-    "Super Lig":  {'url': 'tr/super-lig'},
-    "Belgian 1st Division":  {'url': 'be/first-division-a'},
-}
+from ScraperFC.scraperfc_exceptions import InvalidCurrencyException, InvalidLeagueException, \
+    InvalidYearException
+from ScraperFC.utils import load_comps
 
+comps = load_comps()
 
 class Capology():
 
@@ -74,7 +59,7 @@ class Capology():
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'Capology', list(comps.keys()))
 
-        return f'https://www.capology.com/{comps[league]["url"]}/salaries/'
+        return f'https://www.capology.com/{comps[league]["Capology"]}/salaries/'
 
     # ==============================================================================================
     def get_valid_seasons(self, league: str) -> Sequence[str]:

--- a/src/ScraperFC/capology.py
+++ b/src/ScraperFC/capology.py
@@ -14,7 +14,7 @@ from ScraperFC.scraperfc_exceptions import InvalidCurrencyException, InvalidLeag
     InvalidYearException
 from ScraperFC.utils import get_module_comps
 
-comps = get_module_comps("Capology")
+comps = get_module_comps("CAPOLOGY")
 
 class Capology():
 
@@ -59,7 +59,7 @@ class Capology():
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'Capology', list(comps.keys()))
 
-        return f'https://www.capology.com/{comps[league]["Capology"]}/salaries/'
+        return f'https://www.capology.com/{comps[league]["CAPOLOGY"]}/salaries/'
 
     # ==============================================================================================
     def get_valid_seasons(self, league: str) -> Sequence[str]:

--- a/src/ScraperFC/comps.yaml
+++ b/src/ScraperFC/comps.yaml
@@ -1,37 +1,107 @@
+Argentina Liga Profesional:
+  Sofascore: 155
+  Transfermarkt: https://www.transfermarkt.us/superliga/startseite/wettbewerb/AR1N
+Argentina Copa de la Liga Profesional:
+  Sofascore: 13475
 Belgium Pro League:
   Capology: be/first-division-a
+  Transfermarkt: https://www.transfermarkt.us/jupiler-pro-league/startseite/wettbewerb/BE1
+Brazil Serie A:
+  Transfermarkt: https://www.transfermarkt.us/campeonato-brasileiro-serie-a/startseite/wettbewerb/BRA1
+CONCACAF Gold Cup:
+  Sofascore: 140
+CONMEBOL Copa Libertadores:
+  Sofascore: 384
 England Premier League:
   Capology: uk/premier-league
+  Sofascore: 17
+  Transfermarkt: https://www.transfermarkt.us/premier-league/startseite/wettbewerb/GB1
   Understat: https://understat.com/league/EPL
 England EFL Championship:
   Capology: uk/championship
+  Transfermarkt: https://www.transfermarkt.us/championship/startseite/wettbewerb/GB2
+England EFL League 1:
+  Transfermarkt: https://www.transfermarkt.us/league-one/startseite/wettbewerb/GB3
+England EFL League 2:
+  Transfermarkt: https://www.transfermarkt.us/league-two/startseite/wettbewerb/GB4
+FIFA World Cup:
+  Sofascore: 16
+FIFA Womens World Cup:
+  Sofascore: 290
 France Ligue 1:
   Capology: fr/ligue-1
+  Sofascore: 34
+  Transfermarkt: https://www.transfermarkt.us/ligue-1/startseite/wettbewerb/FR1
   Understat: https://understat.com/league/Ligue_1
 France Ligue 2:
   Capology: fr/ligue-2
+  Transfermarkt: https://www.transfermarkt.us/ligue-2/startseite/wettbewerb/FR2
 Germany Bundesliga:
   Capology: de/1-bundesliga
+  Sofascore: 35
+  Transfermarkt: https://www.transfermarkt.us/bundesliga/startseite/wettbewerb/L1
   Understat: https://understat.com/league/Bundesliga
 Germany 2.Bundesliga:
   Capology: de/2-bundesliga
+  Transfermarkt: https://www.transfermarkt.us/2-bundesliga/startseite/wettbewerb/L2
 Italy Serie A:
   Capology: it/serie-a
+  Sofascore: 23
+  Transfermarkt: https://www.transfermarkt.us/serie-a/startseite/wettbewerb/IT1
   Understat: https://understat.com/league/Serie_A
 Italy Serie B:
   Capology: it/serie-b
+  Transfermarkt: https://www.transfermarkt.us/serie-b/startseite/wettbewerb/IT2
+Italy Primavera 1:
+  Transfermarkt: https://www.transfermarkt.us/primavera-1/startseite/wettbewerb/IJ1
+Italy Primavera 2 - A:
+  Transfermarkt: https://www.transfermarkt.us/primavera-2a/startseite/wettbewerb/IJ2A
+Italy Primavera 2 - B:
+  Transfermarkt: https://www.transfermarkt.us/primavera-2b/startseite/wettbewerb/IJ2B
+Italy Campionato U18:
+  Transfermarkt: https://www.transfermarkt.us/campionato-nazionale-under-18/startseite/wettbewerb/ITJ7
 Netherlands Eredivisie:
   Capology: ne/eredivisie
+  Transfermarkt: https://www.transfermarkt.us/eredivisie/startseite/wettbewerb/NL1
+Peru Liga 1:
+  Sofascore: 406
 Portugal Primeira Liga:
   Capology: pt/primeira-liga
+  Transfermarkt: https://www.transfermarkt.us/liga-nos/startseite/wettbewerb/PO1
 Russia Premier League:
+  Transfermarkt: https://www.transfermarkt.us/premier-liga/startseite/wettbewerb/RU1
   Understat: https://understat.com/league/RFPL
+Saudi Arabia Pro League:
+  Sofascore: 955
 Scotland Premier League:
   Capology: uk/scottish-premiership
+  Transfermarkt: https://www.transfermarkt.us/scottish-premiership/startseite/wettbewerb/SC1
 Spain La Liga:
   Capology: es/la-liga
+  Sofascore: 8
+  Transfermarkt: https://www.transfermarkt.us/laliga/startseite/wettbewerb/ES1
   Understat: https://understat.com/league/La_liga
 Spain La Liga 2:
   Capology: es/la-liga-2
+  Transfermarkt: https://www.transfermarkt.us/laliga2/startseite/wettbewerb/ES2
 Turkiye Super Lig:
   Capology: tr/super-lig
+  Sofascore: 52
+  Transfermarkt: https://www.transfermarkt.us/super-lig/startseite/wettbewerb/TR1
+UEFA Champions League:
+  Sofascore: 7
+UEFA Europa League:
+  Sofascore: 679
+UEFA Europa Conference League:
+  Sofascore: 17015
+UEFA European Championship:
+  Sofascore: 1
+USA MLS:
+  Sofascore: 242
+  Transfermarkt: https://www.transfermarkt.us/major-league-soccer/startseite/wettbewerb/MLS1
+USA USL championship:
+  Sofascore: 13363
+USA USL League 1:
+  Sofascore: 13362
+USA USL Leauge 2:
+  Sofascore: 13546

--- a/src/ScraperFC/comps.yaml
+++ b/src/ScraperFC/comps.yaml
@@ -21,6 +21,8 @@ Brazil Serie A:
     history url: https://fbref.com/en/comps/24/history/Serie-A-Seasons
     finders: [Serie-A]
   TRANSFERMARKT: https://www.transfermarkt.us/campeonato-brasileiro-serie-a/startseite/wettbewerb/BRA1
+Bulgaria Parva Liga:
+  SOFASCORE: 247
 CONCACAF Gold Cup:
   SOFASCORE: 140
 CONMEBOL Copa America:
@@ -212,6 +214,8 @@ UEFA Womens Champions League:
   FBREF:
     history url: https://fbref.com/en/comps/181/history/Champions-League-Seasons
     finders: ['Champions-League']
+Ukraine Premier League:
+  SOFASCORE: 218
 USA MLS:
   FBREF:
     history url: https://fbref.com/en/comps/22/history/Major-League-Soccer-Seasons

--- a/src/ScraperFC/comps.yaml
+++ b/src/ScraperFC/comps.yaml
@@ -1,107 +1,238 @@
 Argentina Liga Profesional:
-  Sofascore: 155
-  Transfermarkt: https://www.transfermarkt.us/superliga/startseite/wettbewerb/AR1N
+  FBREF:
+    history url: https://fbref.com/en/comps/21/history/Primera-Division-Seasons
+    finders: [Primera-Division]
+  SOFASCORE: 155
+  TRANSFERMARKT: https://www.transfermarkt.us/superliga/startseite/wettbewerb/AR1N
 Argentina Copa de la Liga Profesional:
-  Sofascore: 13475
+  SOFASCORE: 13475
+Australia A-League Women:
+  FBREF:
+    history url: https://fbref.com/en/comps/196/history/A-League-Women-Seasons
+    finders: ['A-League-Women', 'W-League']
 Belgium Pro League:
-  Capology: be/first-division-a
-  Transfermarkt: https://www.transfermarkt.us/jupiler-pro-league/startseite/wettbewerb/BE1
+  CAPOLOGY: be/first-division-a
+  FBREF:
+    history url: https://fbref.com/en/comps/37/history/Belgian-Pro-League-Seasons
+    finders: [Belgian-Pro-League, Belgian-First-Division]
+  TRANSFERMARKT: https://www.transfermarkt.us/jupiler-pro-league/startseite/wettbewerb/BE1
 Brazil Serie A:
-  Transfermarkt: https://www.transfermarkt.us/campeonato-brasileiro-serie-a/startseite/wettbewerb/BRA1
+  FBREF:
+    history url: https://fbref.com/en/comps/24/history/Serie-A-Seasons
+    finders: [Serie-A]
+  TRANSFERMARKT: https://www.transfermarkt.us/campeonato-brasileiro-serie-a/startseite/wettbewerb/BRA1
 CONCACAF Gold Cup:
-  Sofascore: 140
+  SOFASCORE: 140
+CONMEBOL Copa America:
+  FBREF:
+    history url: https://fbref.com/en/comps/685/history/Copa-America-Seasons
+    finders: [Copa-America]
 CONMEBOL Copa Libertadores:
-  Sofascore: 384
+  FBREF:
+    history url: https://fbref.com/en/comps/14/history/Copa-Libertadores-Seasons
+    finders: [Copa-Libertadores]
+  SOFASCORE: 384
 England Premier League:
-  Capology: uk/premier-league
-  Sofascore: 17
-  Transfermarkt: https://www.transfermarkt.us/premier-league/startseite/wettbewerb/GB1
-  Understat: https://understat.com/league/EPL
+  CAPOLOGY: uk/premier-league
+  FBREF:
+    history url: https://fbref.com/en/comps/9/history/Premier-League-Seasons
+    finders: [Premier-League, First-Division]
+  SOFASCORE: 17
+  TRANSFERMARKT: https://www.transfermarkt.us/premier-league/startseite/wettbewerb/GB1
+  UNDERSTAT: https://understat.com/league/EPL
 England EFL Championship:
-  Capology: uk/championship
-  Transfermarkt: https://www.transfermarkt.us/championship/startseite/wettbewerb/GB2
+  CAPOLOGY: uk/championship
+  FBREF:
+    history url: https://fbref.com/en/comps/10/history/Championship-Seasons
+    finders: [First-Division, Championship]
+  TRANSFERMARKT: https://www.transfermarkt.us/championship/startseite/wettbewerb/GB2
 England EFL League 1:
-  Transfermarkt: https://www.transfermarkt.us/league-one/startseite/wettbewerb/GB3
+  TRANSFERMARKT: https://www.transfermarkt.us/league-one/startseite/wettbewerb/GB3
 England EFL League 2:
-  Transfermarkt: https://www.transfermarkt.us/league-two/startseite/wettbewerb/GB4
+  TRANSFERMARKT: https://www.transfermarkt.us/league-two/startseite/wettbewerb/GB4
+England WSL:
+  FBREF:
+    history url: https://fbref.com/en/comps/189/history/Womens-Super-League-Seasons
+    finders: ['Womens-Super-League']
+FBref Big 5 Combined:
+  FBREF:
+    history url: https://fbref.com/en/comps/Big5/history/Big-5-European-Leagues-Seasons
+    finders: [Big-5-European-Leagues]
 FIFA World Cup:
-  Sofascore: 16
+  FBREF:
+    history url: https://fbref.com/en/comps/1/history/World-Cup-Seasons
+    finders: [World-Cup]
+  SOFASCORE: 16
 FIFA Womens World Cup:
-  Sofascore: 290
+  FBREF:
+    history url: https://fbref.com/en/comps/106/history/Womens-World-Cup-Seasons
+    finders: ['Womens-World-Cup']
+  SOFASCORE: 290
 France Ligue 1:
-  Capology: fr/ligue-1
-  Sofascore: 34
-  Transfermarkt: https://www.transfermarkt.us/ligue-1/startseite/wettbewerb/FR1
-  Understat: https://understat.com/league/Ligue_1
+  CAPOLOGY: fr/ligue-1
+  FBREF:
+    history url: https://fbref.com/en/comps/13/history/Ligue-1-Seasons
+    finders: [Ligue-1, Division-1]
+  SOFASCORE: 34
+  TRANSFERMARKT: https://www.transfermarkt.us/ligue-1/startseite/wettbewerb/FR1
+  UNDERSTAT: https://understat.com/league/Ligue_1
 France Ligue 2:
-  Capology: fr/ligue-2
-  Transfermarkt: https://www.transfermarkt.us/ligue-2/startseite/wettbewerb/FR2
+  CAPOLOGY: fr/ligue-2
+  FBREF:
+    history url: https://fbref.com/en/comps/60/history/Ligue-2-Seasons
+    finders: ['Ligue-2']
+  TRANSFERMARKT: https://www.transfermarkt.us/ligue-2/startseite/wettbewerb/FR2
+France Premiere Ligue:
+  FBREF:
+    history url: https://fbref.com/en/comps/193/history/Division-1-Feminine-Seasons
+    finders: ['Division-1-Feminine', 'Premiere-Ligue']
 Germany Bundesliga:
-  Capology: de/1-bundesliga
-  Sofascore: 35
-  Transfermarkt: https://www.transfermarkt.us/bundesliga/startseite/wettbewerb/L1
-  Understat: https://understat.com/league/Bundesliga
+  CAPOLOGY: de/1-bundesliga
+  FBREF:
+    history url: https://fbref.com/en/comps/20/history/Bundesliga-Seasons
+    finders: [Bundesliga]
+  SOFASCORE: 35
+  TRANSFERMARKT: https://www.transfermarkt.us/bundesliga/startseite/wettbewerb/L1
+  UNDERSTAT: https://understat.com/league/Bundesliga
 Germany 2.Bundesliga:
-  Capology: de/2-bundesliga
-  Transfermarkt: https://www.transfermarkt.us/2-bundesliga/startseite/wettbewerb/L2
+  CAPOLOGY: de/2-bundesliga
+  FBREF:
+    history url: https://fbref.com/en/comps/33/history/2-Bundesliga-Seasons
+    finders: ['2-Bundesliga']
+  TRANSFERMARKT: https://www.transfermarkt.us/2-bundesliga/startseite/wettbewerb/L2
+Germany Womens Bundesliga:
+  FBREF:
+    history url: https://fbref.com/en/comps/183/history/Frauen-Bundesliga-Seasons
+    finders: ['Frauen-Bundesliga']
 Italy Serie A:
-  Capology: it/serie-a
-  Sofascore: 23
-  Transfermarkt: https://www.transfermarkt.us/serie-a/startseite/wettbewerb/IT1
-  Understat: https://understat.com/league/Serie_A
+  CAPOLOGY: it/serie-a
+  FBREF:
+    history url: https://fbref.com/en/comps/11/history/Serie-A-Seasons
+    finders: [Serie-A]
+  SOFASCORE: 23
+  TRANSFERMARKT: https://www.transfermarkt.us/serie-a/startseite/wettbewerb/IT1
+  UNDERSTAT: https://understat.com/league/Serie_A
 Italy Serie B:
-  Capology: it/serie-b
-  Transfermarkt: https://www.transfermarkt.us/serie-b/startseite/wettbewerb/IT2
+  CAPOLOGY: it/serie-b
+  FBREF:
+    history url: https://fbref.com/en/comps/18/history/Serie-B-Seasons
+    finders: ['Serie-B']
+  TRANSFERMARKT: https://www.transfermarkt.us/serie-b/startseite/wettbewerb/IT2
 Italy Primavera 1:
-  Transfermarkt: https://www.transfermarkt.us/primavera-1/startseite/wettbewerb/IJ1
+  TRANSFERMARKT: https://www.transfermarkt.us/primavera-1/startseite/wettbewerb/IJ1
 Italy Primavera 2 - A:
-  Transfermarkt: https://www.transfermarkt.us/primavera-2a/startseite/wettbewerb/IJ2A
+  TRANSFERMARKT: https://www.transfermarkt.us/primavera-2a/startseite/wettbewerb/IJ2A
 Italy Primavera 2 - B:
-  Transfermarkt: https://www.transfermarkt.us/primavera-2b/startseite/wettbewerb/IJ2B
+  TRANSFERMARKT: https://www.transfermarkt.us/primavera-2b/startseite/wettbewerb/IJ2B
 Italy Campionato U18:
-  Transfermarkt: https://www.transfermarkt.us/campionato-nazionale-under-18/startseite/wettbewerb/ITJ7
+  TRANSFERMARKT: https://www.transfermarkt.us/campionato-nazionale-under-18/startseite/wettbewerb/ITJ7
+Italy Womens Serie A:
+  FBREF:
+    history url: https://fbref.com/en/comps/208/history/Serie-A-Seasons
+    finders: ['Serie-A']
+Mexico Liga MX:
+  FBREF:
+    history url: https://fbref.com/en/comps/31/history/Liga-MX-Seasons
+    finders: [Primera-Division, Liga-MX]
 Netherlands Eredivisie:
-  Capology: ne/eredivisie
-  Transfermarkt: https://www.transfermarkt.us/eredivisie/startseite/wettbewerb/NL1
+  CAPOLOGY: ne/eredivisie
+  FBREF:
+    history url: https://fbref.com/en/comps/23/history/Eredivisie-Seasons
+    finders: [Eredivisie]
+  TRANSFERMARKT: https://www.transfermarkt.us/eredivisie/startseite/wettbewerb/NL1
 Peru Liga 1:
-  Sofascore: 406
+  SOFASCORE: 406
 Portugal Primeira Liga:
-  Capology: pt/primeira-liga
-  Transfermarkt: https://www.transfermarkt.us/liga-nos/startseite/wettbewerb/PO1
+  CAPOLOGY: pt/primeira-liga
+  FBREF:
+    history url: https://fbref.com/en/comps/32/history/Primeira-Liga-Seasons
+    finders: [Primeira-Liga]
+  TRANSFERMARKT: https://www.transfermarkt.us/liga-nos/startseite/wettbewerb/PO1
 Russia Premier League:
-  Transfermarkt: https://www.transfermarkt.us/premier-liga/startseite/wettbewerb/RU1
-  Understat: https://understat.com/league/RFPL
+  TRANSFERMARKT: https://www.transfermarkt.us/premier-liga/startseite/wettbewerb/RU1
+  UNDERSTAT: https://understat.com/league/RFPL
 Saudi Arabia Pro League:
-  Sofascore: 955
+  FBREF:
+    history url: https://fbref.com/en/comps/70/history/Saudi-Professional-League-Seasons
+    finders: [Saudi-Professional-League]
+  SOFASCORE: 955
 Scotland Premier League:
-  Capology: uk/scottish-premiership
-  Transfermarkt: https://www.transfermarkt.us/scottish-premiership/startseite/wettbewerb/SC1
+  CAPOLOGY: uk/scottish-premiership
+  TRANSFERMARKT: https://www.transfermarkt.us/scottish-premiership/startseite/wettbewerb/SC1
 Spain La Liga:
-  Capology: es/la-liga
-  Sofascore: 8
-  Transfermarkt: https://www.transfermarkt.us/laliga/startseite/wettbewerb/ES1
-  Understat: https://understat.com/league/La_liga
+  CAPOLOGY: es/la-liga
+  FBREF:
+    history url: https://fbref.com/en/comps/12/history/La-Liga-Seasons
+    finders: [La-Liga]
+  SOFASCORE: 8
+  TRANSFERMARKT: https://www.transfermarkt.us/laliga/startseite/wettbewerb/ES1
+  UNDERSTAT: https://understat.com/league/La_liga
 Spain La Liga 2:
-  Capology: es/la-liga-2
-  Transfermarkt: https://www.transfermarkt.us/laliga2/startseite/wettbewerb/ES2
+  CAPOLOGY: es/la-liga-2
+  FBREF:
+    history url: https://fbref.com/en/comps/17/history/Segunda-Division-Seasons
+    finders: ['Segunda-Division']
+  TRANSFERMARKT: https://www.transfermarkt.us/laliga2/startseite/wettbewerb/ES2
+Spain Liga F:
+  FBREF:
+    history url: https://fbref.com/en/comps/230/history/Liga-F-Seasons
+    finders: ['Liga-F']
 Turkiye Super Lig:
-  Capology: tr/super-lig
-  Sofascore: 52
-  Transfermarkt: https://www.transfermarkt.us/super-lig/startseite/wettbewerb/TR1
+  CAPOLOGY: tr/super-lig
+  FBREF:
+    history url: https://fbref.com/en/comps/26/history/Super-Lig-Seasons
+    finders: [Super-Lig]
+  SOFASCORE: 52
+  TRANSFERMARKT: https://www.transfermarkt.us/super-lig/startseite/wettbewerb/TR1
 UEFA Champions League:
-  Sofascore: 7
+  FBREF:
+    history url: https://fbref.com/en/comps/8/history/Champions-League-Seasons
+    finders: [European-Cup, Champions-League]
+  SOFASCORE: 7
 UEFA Europa League:
-  Sofascore: 679
+  FBREF:
+    history url: https://fbref.com/en/comps/19/history/Europa-League-Seasons
+    finders: [UEFA-Cup, Europa-League]
+  SOFASCORE: 679
 UEFA Europa Conference League:
-  Sofascore: 17015
+  FBREF:
+    history url: https://fbref.com/en/comps/882/history/Europa-Conference-League-Seasons
+    finders: [Europa-Conference-League]
+  SOFASCORE: 17015
 UEFA European Championship:
-  Sofascore: 1
+  FBREF:
+    history url: https://fbref.com/en/comps/676/history/European-Championship-Seasons
+    finders: [UEFA-Euro, European-Championship]
+  SOFASCORE: 1
+UEFA Womens European Championship:
+  FBREF:
+    history url: https://fbref.com/en/comps/162/history/UEFA-Womens-Euro-Seasons
+    finders: ['UEFA-Womens-Euro']
+UEFA Womens Champions League:
+  FBREF:
+    history url: https://fbref.com/en/comps/181/history/Champions-League-Seasons
+    finders: ['Champions-League']
 USA MLS:
-  Sofascore: 242
-  Transfermarkt: https://www.transfermarkt.us/major-league-soccer/startseite/wettbewerb/MLS1
+  FBREF:
+    history url: https://fbref.com/en/comps/22/history/Major-League-Soccer-Seasons
+    finders: [Major-League-Soccer]
+  SOFASCORE: 242
+  TRANSFERMARKT: https://www.transfermarkt.us/major-league-soccer/startseite/wettbewerb/MLS1
 USA USL championship:
-  Sofascore: 13363
+  SOFASCORE: 13363
 USA USL League 1:
-  Sofascore: 13362
+  SOFASCORE: 13362
 USA USL Leauge 2:
-  Sofascore: 13546
+  SOFASCORE: 13546
+USA NWSL:
+  FBREF:
+    history url: https://fbref.com/en/comps/182/history/NWSL-Seasons
+    finders: [NWSL]
+USA NWSL Challenge Cup:
+  FBREF:
+    history url: https://fbref.com/en/comps/881/history/NWSL-Challenge-Cup-Seasons
+    finders: ['NWSL-Challenge-Cup']
+USA NWSL Fall Series:
+  FBREF:
+    history url: https://fbref.com/en/comps/884/history/NWSL-Fall-Series-Seasons
+    finders: ['NWSL-Fall-Series']

--- a/src/ScraperFC/comps.yaml
+++ b/src/ScraperFC/comps.yaml
@@ -1,0 +1,30 @@
+Belgium Pro League:
+  Capology: be/first-division-a
+England Premier League:
+  Capology: uk/premier-league
+England EFL Championship:
+  Capology: uk/championship
+France Ligue 1:
+  Capology: fr/ligue-1
+France Ligue 2:
+  Capology: fr/ligue-2
+Germany Bundesliga:
+  Capology: de/1-bundesliga
+Germany 2.Bundesliga:
+  Capology: de/2-bundesliga
+Italy Serie A:
+  Capology: it/serie-a
+Italy Serie B:
+  Capology: it/serie-b
+Netherlands Eredivisie:
+  Capology: ne/eredivisie
+Portugal Primeira Liga:
+  Capology: pt/primeira-liga
+Scotland Premier League:
+  Capology: uk/scottish-premiership
+Spain La Liga:
+  Capology: es/la-liga
+Spain La Liga 2:
+  Capology: es/la-liga-2
+Turkiye Super Lig:
+  Capology: tr/super-lig

--- a/src/ScraperFC/comps.yaml
+++ b/src/ScraperFC/comps.yaml
@@ -2,28 +2,35 @@ Belgium Pro League:
   Capology: be/first-division-a
 England Premier League:
   Capology: uk/premier-league
+  Understat: https://understat.com/league/EPL
 England EFL Championship:
   Capology: uk/championship
 France Ligue 1:
   Capology: fr/ligue-1
+  Understat: https://understat.com/league/Ligue_1
 France Ligue 2:
   Capology: fr/ligue-2
 Germany Bundesliga:
   Capology: de/1-bundesliga
+  Understat: https://understat.com/league/Bundesliga
 Germany 2.Bundesliga:
   Capology: de/2-bundesliga
 Italy Serie A:
   Capology: it/serie-a
+  Understat: https://understat.com/league/Serie_A
 Italy Serie B:
   Capology: it/serie-b
 Netherlands Eredivisie:
   Capology: ne/eredivisie
 Portugal Primeira Liga:
   Capology: pt/primeira-liga
+Russia Premier League:
+  Understat: https://understat.com/league/RFPL
 Scotland Premier League:
   Capology: uk/scottish-premiership
 Spain La Liga:
   Capology: es/la-liga
+  Understat: https://understat.com/league/La_liga
 Spain La Liga 2:
   Capology: es/la-liga-2
 Turkiye Super Lig:

--- a/src/ScraperFC/fbref.py
+++ b/src/ScraperFC/fbref.py
@@ -409,7 +409,7 @@ class FBref():
 
         season_url = self.get_season_link(year, league)
 
-        if league == 'Big 5 combined':
+        if 'big 5 combined' in league.lower():
             squad_id_finder = "td"  # for squad and opponent squad IDs
             squad_id_start_idx = 0  # to index the squad id elements list, to match shape of df
             # Big 5 combined has separate pages for squad and player stats

--- a/src/ScraperFC/fbref.py
+++ b/src/ScraperFC/fbref.py
@@ -1,8 +1,6 @@
 from bs4 import BeautifulSoup
 import requests
 from cloudscraper import CloudScraper
-from .scraperfc_exceptions import InvalidYearException, InvalidLeagueException, \
-    NoMatchLinksException, FBrefRateLimitException
 import time
 import pandas as pd
 from io import StringIO
@@ -16,6 +14,10 @@ from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException
 from typing import Sequence, Union
 import warnings
+
+from .scraperfc_exceptions import InvalidYearException, InvalidLeagueException, \
+    NoMatchLinksException, FBrefRateLimitException
+from .utils import get_module_comps
 
 stats_categories = {
     'standard': {'url': 'stats', 'html': 'standard'},
@@ -31,134 +33,7 @@ stats_categories = {
     'misc': {'url': 'misc', 'html': 'misc'}
 }
 
-comps = {
-    # Men's club international cups
-    'Copa Libertadores': {
-        'history url': 'https://fbref.com/en/comps/14/history/Copa-Libertadores-Seasons',
-        'finders': ['Copa-Libertadores']},
-    'Champions League': {
-        'history url': 'https://fbref.com/en/comps/8/history/Champions-League-Seasons',
-        'finders': ['European-Cup', 'Champions-League']},
-    'Europa League': {
-        'history url': 'https://fbref.com/en/comps/19/history/Europa-League-Seasons',
-        'finders': ['UEFA-Cup', 'Europa-League']},
-    'Europa Conference League': {
-        'history url': 'https://fbref.com/en/comps/882/history/Europa-Conference-League-Seasons',
-        'finders': ['Europa-Conference-League']},
-    # Men's national team competitions
-    'World Cup': {
-        'history url': 'https://fbref.com/en/comps/1/history/World-Cup-Seasons',
-        'finders': ['World-Cup']},
-    'Copa America': {
-        'history url': 'https://fbref.com/en/comps/685/history/Copa-America-Seasons',
-        'finders': ['Copa-America']},
-    'Euros': {
-        'history url': 'https://fbref.com/en/comps/676/history/European-Championship-Seasons',
-        'finders': ['UEFA-Euro', 'European-Championship']},
-    # Men's big 5
-    'Big 5 combined': {
-        'history url': 'https://fbref.com/en/comps/Big5/history/Big-5-European-Leagues-Seasons',
-        'finders': ['Big-5-European-Leagues']},
-    'EPL': {
-        'history url': 'https://fbref.com/en/comps/9/history/Premier-League-Seasons',
-        'finders': ['Premier-League', 'First-Division']},
-    'Ligue 1': {
-        'history url': 'https://fbref.com/en/comps/13/history/Ligue-1-Seasons',
-        'finders': ['Ligue-1', 'Division-1']},
-    'Bundesliga': {
-        'history url': 'https://fbref.com/en/comps/20/history/Bundesliga-Seasons',
-        'finders': ['Bundesliga']},
-    'Serie A': {
-        'history url': 'https://fbref.com/en/comps/11/history/Serie-A-Seasons',
-        'finders': ['Serie-A']},
-    'La Liga': {
-        'history url': 'https://fbref.com/en/comps/12/history/La-Liga-Seasons',
-        'finders': ['La-Liga']},
-    # Men's domestic leagues - 1st tier
-    'MLS': {
-        'history url': 'https://fbref.com/en/comps/22/history/Major-League-Soccer-Seasons',
-        'finders': ['Major-League-Soccer']},
-    'Brazilian Serie A': {
-        'history url': 'https://fbref.com/en/comps/24/history/Serie-A-Seasons',
-        'finders': ['Serie-A']},
-    'Eredivisie': {
-        'history url': 'https://fbref.com/en/comps/23/history/Eredivisie-Seasons',
-        'finders': ['Eredivisie']},
-    'Liga MX': {
-        'history url': 'https://fbref.com/en/comps/31/history/Liga-MX-Seasons',
-        'finders': ['Primera-Division', 'Liga-MX']},
-    'Primeira Liga': {
-        'history url': 'https://fbref.com/en/comps/32/history/Primeira-Liga-Seasons',
-        'finders': ['Primeira-Liga']},
-    'Belgian Pro League': {
-        'history url': 'https://fbref.com/en/comps/37/history/Belgian-Pro-League-Seasons',
-        'finders': ['Belgian-Pro-League', 'Belgian-First-Division']},
-    'Argentina Liga Profesional': {
-        'history url': 'https://fbref.com/en/comps/21/history/Primera-Division-Seasons',
-        'finders': ['Primera-Division']},
-    "Saudi Pro League": {
-        "history url": "https://fbref.com/en/comps/70/history/Saudi-Professional-League-Seasons",
-        "finders": ["Saudi-Professional-League"]},
-    "Turkish Super Lig": {
-        "history url": "https://fbref.com/en/comps/26/history/Super-Lig-Seasons",
-        "finders": ["Super-Lig"]},
-    # Men's domestic league - 2nd tier
-    'EFL Championship': {
-        'history url': 'https://fbref.com/en/comps/10/history/Championship-Seasons',
-        'finders': ['First-Division', 'Championship']},
-    'La Liga 2': {
-        'history url': 'https://fbref.com/en/comps/17/history/Segunda-Division-Seasons',
-        'finders': ['Segunda-Division']},
-    '2. Bundesliga': {
-        'history url': 'https://fbref.com/en/comps/33/history/2-Bundesliga-Seasons',
-        'finders': ['2-Bundesliga']},
-    'Ligue 2': {
-        'history url': 'https://fbref.com/en/comps/60/history/Ligue-2-Seasons',
-        'finders': ['Ligue-2']},
-    'Serie B': {
-        'history url': 'https://fbref.com/en/comps/18/history/Serie-B-Seasons',
-        'finders': ['Serie-B']},
-    # Women's internation club competitions
-    'Womens Champions League': {
-        'history url': 'https://fbref.com/en/comps/181/history/Champions-League-Seasons',
-        'finders': ['Champions-League']},
-    # Women's national team competitions
-    'Womens World Cup': {
-        'history url': 'https://fbref.com/en/comps/106/history/Womens-World-Cup-Seasons',
-        'finders': ['Womens-World-Cup']},
-    'Womens Euros': {
-        'history url': 'https://fbref.com/en/comps/162/history/UEFA-Womens-Euro-Seasons',
-        'finders': ['UEFA-Womens-Euro']},
-    # Women's domestic leagues
-    'NWSL': {
-        'history url': 'https://fbref.com/en/comps/182/history/NWSL-Seasons',
-        'finders': ['NWSL']},
-    'A-League Women': {
-        'history url': 'https://fbref.com/en/comps/196/history/A-League-Women-Seasons',
-        'finders': ['A-League-Women', 'W-League']},
-    'WSL': {
-        'history url': 'https://fbref.com/en/comps/189/history/Womens-Super-League-Seasons',
-        'finders': ['Womens-Super-League']},
-    'D1 Feminine': {
-        'history url': 'https://fbref.com/en/comps/193/history/Division-1-Feminine-Seasons',
-        'finders': ['Division-1-Feminine']},
-    'Womens Bundesliga': {
-        'history url': 'https://fbref.com/en/comps/183/history/Frauen-Bundesliga-Seasons',
-        'finders': ['Frauen-Bundesliga']},
-    'Womens Serie A': {
-        'history url': 'https://fbref.com/en/comps/208/history/Serie-A-Seasons',
-        'finders': ['Serie-A']},
-    'Liga F': {
-        'history url': 'https://fbref.com/en/comps/230/history/Liga-F-Seasons',
-        'finders': ['Liga-F']},
-    # Women's domestic cups
-    'NWSL Challenge Cup': {
-        'history url': 'https://fbref.com/en/comps/881/history/NWSL-Challenge-Cup-Seasons',
-        'finders': ['NWSL-Challenge-Cup']},
-    'NWSL Fall Series': {
-        'history url': 'https://fbref.com/en/comps/884/history/NWSL-Fall-Series-Seasons',
-        'finders': ['NWSL-Fall-Series']},
-}
+comps = get_module_comps("FBREF")
 
 
 class FBref():
@@ -228,7 +103,7 @@ class FBref():
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'FBref', list(comps.keys()))
 
-        url = comps[league]['history url']  # type: ignore
+        url = comps[league]["FBREF"]['history url']  # type: ignore
         r = self._get(url)  # type: ignore
         soup = BeautifulSoup(r.content, 'html.parser')
 
@@ -316,7 +191,7 @@ class FBref():
         for x in possible_els:
             a = x.find('a')
             if (a is not None and 'match' in a['href']
-                    and any([f in a['href'] for f in comps[league]['finders']])
+                    and any([f in a['href'] for f in comps[league]["FBREF"]['finders']])
                 ):
                 match_urls.append('https://fbref.com' + a['href'])
         match_urls = list(set(match_urls))

--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -1,9 +1,10 @@
 import pandas as pd
-from .scraperfc_exceptions import InvalidLeagueException, InvalidYearException
-from .utils import botasaurus_browser_get_json
 import numpy as np
 from typing import Union, Sequence
 import warnings
+
+from .scraperfc_exceptions import InvalidLeagueException, InvalidYearException
+from .utils import botasaurus_browser_get_json, get_module_comps
 
 """ These are the status codes for Sofascore events. Found in event['status'] key.
 {100: {'code': 100, 'description': 'Ended', 'type': 'finished'},
@@ -20,23 +21,7 @@ import warnings
 
 API_PREFIX = 'https://api.sofascore.com/api/v1'
 
-comps = {
-    # European continental club comps
-    'Champions League': 7, 'Europa League': 679, 'Europa Conference League': 17015,
-    # European domestic leagues
-    'EPL': 17, 'La Liga': 8, 'Bundesliga': 35, 'Serie A': 23, 'Ligue 1': 34, 'Turkish Super Lig': 52,
-    # South America
-    'Argentina Liga Profesional': 155, 'Argentina Copa de la Liga Profesional': 13475,
-    'Liga 1 Peru': 406, "Copa Libertadores": 384,
-    # USA
-    'MLS': 242, 'USL Championship': 13363, 'USL1': 13362, 'USL2': 13546,
-    # Middle East
-    "Saudi Pro League": 955,
-    # Men's international comps
-    'World Cup': 16, 'Euros': 1, 'Gold Cup': 140,
-    # Women's international comps
-    "Women's World Cup": 290
-}
+comps = get_module_comps("Sofascore")
 
 
 class Sofascore:
@@ -97,7 +82,8 @@ class Sofascore:
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'Sofascore', list(comps.keys()))
 
-        response = botasaurus_browser_get_json(f'{API_PREFIX}/unique-tournament/{comps[league]}/seasons/')
+        url = f'{API_PREFIX}/unique-tournament/{comps[league]["Sofascore"]}/seasons/'
+        response = botasaurus_browser_get_json(url)
         seasons = dict([(x['year'], x['id']) for x in response['seasons']])
         return seasons
 
@@ -127,8 +113,8 @@ class Sofascore:
         i = 0
         while 1:
             response = botasaurus_browser_get_json(
-                f'{API_PREFIX}/unique-tournament/{comps[league]}/season/' +
-                f'{valid_seasons[year]}/events/last/{i}'
+                f'{API_PREFIX}/unique-tournament/{comps[league]["Sofascore"]}/' +
+                f'season/{valid_seasons[year]}/events/last/{i}'
             )
             if 'events' not in response:
                 break
@@ -313,7 +299,7 @@ class Sofascore:
 
         positions = self.get_positions(selected_positions)
         season_id = valid_seasons[year]
-        league_id = comps[league]
+        league_id = comps[league]["Sofascore"]
 
         # Get all player stats from Sofascore API
         offset = 0

--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -21,7 +21,7 @@ from .utils import botasaurus_browser_get_json, get_module_comps
 
 API_PREFIX = 'https://api.sofascore.com/api/v1'
 
-comps = get_module_comps("Sofascore")
+comps = get_module_comps("SOFASCORE")
 
 
 class Sofascore:
@@ -82,7 +82,7 @@ class Sofascore:
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'Sofascore', list(comps.keys()))
 
-        url = f'{API_PREFIX}/unique-tournament/{comps[league]["Sofascore"]}/seasons/'
+        url = f'{API_PREFIX}/unique-tournament/{comps[league]["SOFASCORE"]}/seasons/'
         response = botasaurus_browser_get_json(url)
         seasons = dict([(x['year'], x['id']) for x in response['seasons']])
         return seasons
@@ -113,7 +113,7 @@ class Sofascore:
         i = 0
         while 1:
             response = botasaurus_browser_get_json(
-                f'{API_PREFIX}/unique-tournament/{comps[league]["Sofascore"]}/' +
+                f'{API_PREFIX}/unique-tournament/{comps[league]["SOFASCORE"]}/' +
                 f'season/{valid_seasons[year]}/events/last/{i}'
             )
             if 'events' not in response:
@@ -299,7 +299,7 @@ class Sofascore:
 
         positions = self.get_positions(selected_positions)
         season_id = valid_seasons[year]
-        league_id = comps[league]["Sofascore"]
+        league_id = comps[league]["SOFASCORE"]
 
         # Get all player stats from Sofascore API
         offset = 0

--- a/src/ScraperFC/transfermarkt.py
+++ b/src/ScraperFC/transfermarkt.py
@@ -37,7 +37,6 @@ class Transfermarkt():
         scraper = cloudscraper.CloudScraper()
         try:
             response = scraper.get(comps[league]["TRANSFERMARKT"])
-            print(response.status_code)
             soup = BeautifulSoup(response.content, "html.parser")
             season_tags = soup.find("select", {"name": "saison_id"}).find_all("option")  # type: ignore
             valid_seasons = dict([(x.text, x["value"]) for x in season_tags])

--- a/src/ScraperFC/transfermarkt.py
+++ b/src/ScraperFC/transfermarkt.py
@@ -10,7 +10,7 @@ from ScraperFC.utils import get_module_comps
 
 TRANSFERMARKT_ROOT = "https://www.transfermarkt.us"
 
-comps = get_module_comps("Transfermarkt")
+comps = get_module_comps("TRANSFERMARKT")
 
 
 class Transfermarkt():
@@ -36,7 +36,7 @@ class Transfermarkt():
 
         scraper = cloudscraper.CloudScraper()
         try:
-            response = scraper.get(comps[league]["Transfermarkt"])
+            response = scraper.get(comps[league]["TRANSFERMARKT"])
             print(response.status_code)
             soup = BeautifulSoup(response.content, "html.parser")
             season_tags = soup.find("select", {"name": "saison_id"}).find_all("option")  # type: ignore
@@ -70,7 +70,7 @@ class Transfermarkt():
         scraper = cloudscraper.CloudScraper()
         try:
             soup = BeautifulSoup(
-                scraper.get(f"{comps[league]['Transfermarkt']}/plus/?saison_id={valid_seasons[year]}").content,
+                scraper.get(f"{comps[league]['TRANSFERMARKT']}/plus/?saison_id={valid_seasons[year]}").content,
                 "html.parser"
             )
             items_table_tag = soup.find("table", {"class": "items"})
@@ -137,7 +137,7 @@ class Transfermarkt():
             List of the match URLs
         """
         valid_seasons = self.get_valid_seasons(league)
-        fixtures_url = f"{comps[league]['Transfermarkt'].replace('startseite', 'gesamtspielplan')}/saison_id/{valid_seasons[year]}"
+        fixtures_url = f"{comps[league]['TRANSFERMARKT'].replace('startseite', 'gesamtspielplan')}/saison_id/{valid_seasons[year]}"
         scraper = cloudscraper.CloudScraper()
         try:
             soup = BeautifulSoup(scraper.get(fixtures_url).content, "html.parser")

--- a/src/ScraperFC/transfermarkt.py
+++ b/src/ScraperFC/transfermarkt.py
@@ -1,4 +1,3 @@
-from .scraperfc_exceptions import InvalidLeagueException, InvalidYearException
 from tqdm import tqdm
 import requests
 from bs4 import BeautifulSoup
@@ -6,37 +5,12 @@ import pandas as pd
 import cloudscraper
 from typing import Sequence
 import warnings
+from .scraperfc_exceptions import InvalidLeagueException, InvalidYearException
+from ScraperFC.utils import get_module_comps
 
 TRANSFERMARKT_ROOT = "https://www.transfermarkt.us"
 
-comps = {
-    "EPL": "https://www.transfermarkt.us/premier-league/startseite/wettbewerb/GB1",
-    "EFL Championship": "https://www.transfermarkt.us/championship/startseite/wettbewerb/GB2",
-    "EFL1": "https://www.transfermarkt.us/league-one/startseite/wettbewerb/GB3",
-    "EFL2": "https://www.transfermarkt.us/league-two/startseite/wettbewerb/GB4",
-    "Bundesliga": "https://www.transfermarkt.us/bundesliga/startseite/wettbewerb/L1",
-    "2.Bundesliga": "https://www.transfermarkt.us/2-bundesliga/startseite/wettbewerb/L2",
-    "Serie A": "https://www.transfermarkt.us/serie-a/startseite/wettbewerb/IT1",
-    "Serie B": "https://www.transfermarkt.us/serie-b/startseite/wettbewerb/IT2",
-    "La Liga": "https://www.transfermarkt.us/laliga/startseite/wettbewerb/ES1",
-    "La Liga 2": "https://www.transfermarkt.us/laliga2/startseite/wettbewerb/ES2",
-    "Ligue 1": "https://www.transfermarkt.us/ligue-1/startseite/wettbewerb/FR1",
-    "Ligue 2": "https://www.transfermarkt.us/ligue-2/startseite/wettbewerb/FR2",
-    "Eredivisie": "https://www.transfermarkt.us/eredivisie/startseite/wettbewerb/NL1",
-    "Scottish PL": "https://www.transfermarkt.us/scottish-premiership/startseite/wettbewerb/SC1",
-    "Super Lig": "https://www.transfermarkt.us/super-lig/startseite/wettbewerb/TR1",
-    "Jupiler Pro League": "https://www.transfermarkt.us/jupiler-pro-league/startseite/wettbewerb/BE1",  # noqa: E501
-    "Liga Nos": "https://www.transfermarkt.us/liga-nos/startseite/wettbewerb/PO1",
-    "Russian Premier League": "https://www.transfermarkt.us/premier-liga/startseite/wettbewerb/RU1",
-    "Brasileirao": "https://www.transfermarkt.us/campeonato-brasileiro-serie-a/startseite/wettbewerb/BRA1",  # noqa: E501
-    "Argentina Liga Profesional": "https://www.transfermarkt.us/superliga/startseite/wettbewerb/AR1N",  # noqa: E501
-    "MLS": "https://www.transfermarkt.us/major-league-soccer/startseite/wettbewerb/MLS1",
-    "Turkish Super Lig": "https://www.transfermarkt.us/super-lig/startseite/wettbewerb/TR1",
-    "Primavera 1": "https://www.transfermarkt.us/primavera-1/startseite/wettbewerb/IJ1",
-    "Primavera 2 - A": "https://www.transfermarkt.us/primavera-2a/startseite/wettbewerb/IJ2A",
-    "Primavera 2 - B": "https://www.transfermarkt.us/primavera-2b/startseite/wettbewerb/IJ2B",
-    "Campionato U18": "https://www.transfermarkt.us/campionato-nazionale-under-18/startseite/wettbewerb/ITJ7",  # noqa: E501
-}
+comps = get_module_comps("Transfermarkt")
 
 
 class Transfermarkt():
@@ -62,7 +36,9 @@ class Transfermarkt():
 
         scraper = cloudscraper.CloudScraper()
         try:
-            soup = BeautifulSoup(scraper.get(comps[league]).content, "html.parser")
+            response = scraper.get(comps[league]["Transfermarkt"])
+            print(response.status_code)
+            soup = BeautifulSoup(response.content, "html.parser")
             season_tags = soup.find("select", {"name": "saison_id"}).find_all("option")  # type: ignore
             valid_seasons = dict([(x.text, x["value"]) for x in season_tags])
             return valid_seasons
@@ -94,7 +70,7 @@ class Transfermarkt():
         scraper = cloudscraper.CloudScraper()
         try:
             soup = BeautifulSoup(
-                scraper.get(f"{comps[league]}/plus/?saison_id={valid_seasons[year]}").content,
+                scraper.get(f"{comps[league]['Transfermarkt']}/plus/?saison_id={valid_seasons[year]}").content,
                 "html.parser"
             )
             items_table_tag = soup.find("table", {"class": "items"})
@@ -161,7 +137,7 @@ class Transfermarkt():
             List of the match URLs
         """
         valid_seasons = self.get_valid_seasons(league)
-        fixtures_url = f"{comps[league].replace('startseite', 'gesamtspielplan')}/saison_id/{valid_seasons[year]}"
+        fixtures_url = f"{comps[league]['Transfermarkt'].replace('startseite', 'gesamtspielplan')}/saison_id/{valid_seasons[year]}"
         scraper = cloudscraper.CloudScraper()
         try:
             soup = BeautifulSoup(scraper.get(fixtures_url).content, "html.parser")

--- a/src/ScraperFC/understat.py
+++ b/src/ScraperFC/understat.py
@@ -8,7 +8,7 @@ import warnings
 from typing import Sequence, Union
 from ScraperFC.utils import get_module_comps
 
-comps = get_module_comps("Understat")
+comps = get_module_comps("UNDERSTAT")
 
 def _json_from_script(text: str) -> dict:
     data_str = text.split('JSON.parse(\'')[1].split('\')')[0].encode('utf-8').decode('unicode_escape')
@@ -44,7 +44,7 @@ class Understat:
         if year not in valid_seasons:
             raise InvalidYearException(year, league, valid_seasons)
 
-        return f'{comps[league]["Understat"]}/{year.split("/")[0]}'
+        return f'{comps[league]["UNDERSTAT"]}/{year.split("/")[0]}'
 
     # ==============================================================================================
     def get_valid_seasons(self, league: str) -> Sequence[str]:
@@ -63,7 +63,7 @@ class Understat:
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'Understat', list(comps.keys()))
 
-        soup = BeautifulSoup(requests.get(comps[league]["Understat"]).content, 'html.parser')
+        soup = BeautifulSoup(requests.get(comps[league]["UNDERSTAT"]).content, 'html.parser')
         valid_season_tags = soup.find('select', {'name': 'season'}).find_all('option')  # type: ignore
         valid_seasons = [x.text for x in valid_season_tags]
         return valid_seasons

--- a/src/ScraperFC/understat.py
+++ b/src/ScraperFC/understat.py
@@ -6,16 +6,9 @@ import requests
 from bs4 import BeautifulSoup
 import warnings
 from typing import Sequence, Union
+from ScraperFC.utils import get_module_comps
 
-comps = {
-    'EPL': 'https://understat.com/league/EPL',
-    'La Liga': 'https://understat.com/league/La_liga',
-    'Bundesliga': 'https://understat.com/league/Bundesliga',
-    'Serie A': 'https://understat.com/league/Serie_A',
-    'Ligue 1': 'https://understat.com/league/Ligue_1',
-    'RFPL': 'https://understat.com/league/RFPL'
-}
-
+comps = get_module_comps("Understat")
 
 def _json_from_script(text: str) -> dict:
     data_str = text.split('JSON.parse(\'')[1].split('\')')[0].encode('utf-8').decode('unicode_escape')
@@ -51,7 +44,7 @@ class Understat:
         if year not in valid_seasons:
             raise InvalidYearException(year, league, valid_seasons)
 
-        return f'{comps[league]}/{year.split("/")[0]}'
+        return f'{comps[league]["Understat"]}/{year.split("/")[0]}'
 
     # ==============================================================================================
     def get_valid_seasons(self, league: str) -> Sequence[str]:
@@ -70,7 +63,7 @@ class Understat:
         if league not in comps.keys():
             raise InvalidLeagueException(league, 'Understat', list(comps.keys()))
 
-        soup = BeautifulSoup(requests.get(comps[league]).content, 'html.parser')
+        soup = BeautifulSoup(requests.get(comps[league]["Understat"]).content, 'html.parser')
         valid_season_tags = soup.find('select', {'name': 'season'}).find_all('option')  # type: ignore
         valid_seasons = [x.text for x in valid_season_tags]
         return valid_seasons

--- a/src/ScraperFC/utils/__init__.py
+++ b/src/ScraperFC/utils/__init__.py
@@ -1,3 +1,4 @@
 from .get_proxy import get_proxy
 from .xpath_soup import xpath_soup
 from .botasaurus_getters import botasaurus_request_get_json, botasaurus_browser_get_json
+from .load_comps import load_comps

--- a/src/ScraperFC/utils/__init__.py
+++ b/src/ScraperFC/utils/__init__.py
@@ -2,3 +2,4 @@ from .get_proxy import get_proxy
 from .xpath_soup import xpath_soup
 from .botasaurus_getters import botasaurus_request_get_json, botasaurus_browser_get_json
 from .load_comps import load_comps
+from .get_module_comps import get_module_comps

--- a/src/ScraperFC/utils/get_module_comps.py
+++ b/src/ScraperFC/utils/get_module_comps.py
@@ -1,0 +1,8 @@
+from .load_comps import load_comps
+
+def get_module_comps(module: str) -> dict:
+    if not isinstance(module, str):
+        raise TypeError('`module` must be a string.')
+    comps = load_comps()
+    module_comps = dict((k ,v) for k, v in comps.items() if module in v)
+    return module_comps

--- a/src/ScraperFC/utils/load_comps.py
+++ b/src/ScraperFC/utils/load_comps.py
@@ -1,0 +1,7 @@
+import yaml
+from rootutils import find_root
+
+def load_comps() -> dict:
+    with open(find_root() / "src" / "ScraperFC" / "comps.yaml", "r") as f:
+        comps = yaml.safe_load(f)
+    return comps

--- a/test/dev_testing_notebook.py
+++ b/test/dev_testing_notebook.py
@@ -7,32 +7,18 @@ app = marimo.App(width="medium")
 @app.cell
 def _():
     import sys
-    sys.path.append("../src")
+    from rootutils import find_root
+    from cloudscraper import CloudScraper
+    from bs4 import BeautifulSoup
+
+    sys.path.append(str(find_root() / "src"))
     import ScraperFC as sfc
     return (sfc,)
 
 
 @app.cell
 def _(sfc):
-    from ScraperFC.sofascore import API_PREFIX, comps
-
-    ss = sfc.Sofascore()
-
-    league = "EPL"
-    year = "24/25"
-    match_id = 61627
-
-    match_id = ss._check_and_convert_match_id(match_id)
-    url = f"{API_PREFIX}/event/{match_id}/lineups"
-
-    response = sfc.utils.botasaurus_browser_get_json(url)
-    # response = sfc.utils.botasaurus_request_get_json(url)
-    return (response,)
-
-
-@app.cell
-def _(response):
-    response['error']
+    sfc.utils.get_module_comps("FBref")
     return
 
 

--- a/test/test_capology.py
+++ b/test/test_capology.py
@@ -1,13 +1,15 @@
 import sys
 sys.path.append('./src/')
 from ScraperFC import Capology
-from ScraperFC.capology import comps
 from ScraperFC.scraperfc_exceptions import InvalidYearException, InvalidLeagueException
+from ScraperFC.utils import get_module_comps
 
 import pytest
 from contextlib import nullcontext as does_not_raise
 import random
 import pandas as pd
+
+comps = get_module_comps("Capology")
 
 class TestCapology:
 

--- a/test/test_capology.py
+++ b/test/test_capology.py
@@ -14,9 +14,9 @@ class TestCapology:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [(2017, 'EPL', pytest.raises(TypeError)),
-         ('2020-21', 'Bundesliga', does_not_raise()),
-         ('2020-2021', 'Bundesliga', pytest.raises(InvalidYearException))]
+        [(2017, 'England Premier League', pytest.raises(TypeError)),
+         ('2020-21', 'Germany Bundesliga', does_not_raise()),
+         ('2020-2021', 'Germany Bundesliga', pytest.raises(InvalidYearException))]
     )
     def test_invalid_year(self, year, league, expected):
         with expected:
@@ -26,8 +26,8 @@ class TestCapology:
     @pytest.mark.parametrize(
         'year, league, expected',
         [('2021-22', 9, pytest.raises(TypeError)),
-         ('2022-23', 'English Premier League', pytest.raises(InvalidLeagueException)),
-         ('2022-23', 'La Liga', does_not_raise())]
+         ('2022-23', 'EPL', pytest.raises(InvalidLeagueException)),
+         ('2022-23', 'Spain La Liga', does_not_raise())]
     )
     def test_invalid_league(self, year, league, expected):
         with expected:

--- a/test/test_capology.py
+++ b/test/test_capology.py
@@ -9,7 +9,7 @@ from contextlib import nullcontext as does_not_raise
 import random
 import pandas as pd
 
-comps = get_module_comps("Capology")
+comps = get_module_comps("CAPOLOGY")
 
 class TestCapology:
 

--- a/test/test_fbref.py
+++ b/test/test_fbref.py
@@ -1,14 +1,15 @@
 import sys
-sys.path.append('./src/')
-from ScraperFC import FBref
-from ScraperFC.fbref import comps, stats_categories
-from ScraperFC.scraperfc_exceptions import NoMatchLinksException, InvalidLeagueException,\
-    InvalidYearException
-
 import random
 import numpy as np
 import pandas as pd
 import pytest
+
+sys.path.append('./src/')
+from ScraperFC import FBref
+from ScraperFC.fbref import stats_categories
+from ScraperFC.scraperfc_exceptions import NoMatchLinksException, InvalidLeagueException,\
+    InvalidYearException
+from ScraperFC.utils import get_module_comps
 
 # These leagues and years do not have match links on FBref
 comps_wo_matches = [
@@ -31,14 +32,16 @@ comps_wo_matches = [
     ("2012-2013", "2. Bundesliga"), ("2013-2014", "2. Bundesliga"),
 ]
 
+comps = get_module_comps("FBREF")
+
 
 class TestFBref:
 
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [(2021, 'Serie B', pytest.raises(TypeError)),
-         ('1642-1643', 'EPL', pytest.raises(InvalidYearException))]
+        [(2021, 'Italy Serie B', pytest.raises(TypeError)),
+         ('1642-1643', 'England Premier League', pytest.raises(InvalidYearException))]
     )
     def test_invalid_year(self, year, league, expected):
         fbref = FBref()
@@ -59,7 +62,7 @@ class TestFBref:
     @pytest.mark.parametrize(
         'year, league, expected',
         [('2018', (1, 2, 3), pytest.raises(TypeError)),
-         ('2018', 'fake comp', pytest.raises(InvalidLeagueException))]
+         ('2018', 'fake league', pytest.raises(InvalidLeagueException))]
     )
     def test_invalid_league(self, year, league, expected):
         fbref = FBref()
@@ -81,9 +84,9 @@ class TestFBref:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('2013-2014', 'Ligue 2', pytest.raises(NoMatchLinksException)),
-         ('2013-2014', 'La Liga 2', pytest.raises(NoMatchLinksException)),
-         ('2013-2014', 'Belgian Pro League', pytest.raises(NoMatchLinksException)),]
+        [('2013-2014', 'France Ligue 2', pytest.raises(NoMatchLinksException)),
+         ('2013-2014', 'Spain La Liga 2', pytest.raises(NoMatchLinksException)),
+         ('2013-2014', 'Belgium Pro League', pytest.raises(NoMatchLinksException)),]
     )
     def test_NoMatchLinksException(self, year, league, expected):
         fbref = FBref()
@@ -95,7 +98,7 @@ class TestFBref:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected_len',
-        [('2020-2021', 'EPL', 380)]
+        [('2020-2021', 'England Premier League', 380)]
     )
     def test_valid_get_match_links(self, year, league, expected_len):
         fbref = FBref()
@@ -150,7 +153,7 @@ class TestFBref:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, stat_category, expected',
-        [('2023-2024', 'Big 5 combined', 'fake category', pytest.raises(ValueError))]
+        [('2023-2024', 'FBref Big 5 Combined', 'fake category', pytest.raises(ValueError))]
     )
     def test_fake_stat_category(self, year, league, stat_category, expected):
         fbref = FBref()
@@ -170,9 +173,6 @@ class TestFBref:
             assert type(stats) is tuple
             assert not stats[0]
 
-
-
-
         assert type(stats) is dict
         for key, value in stats.items():
             assert key in stats_categories.keys()
@@ -186,9 +186,9 @@ class TestFBref:
     @pytest.mark.parametrize(
         "year, league",
         [
-            ("1954-1955", "EPL"),  # doesn't have any stat categories data
-            ("2024-2025", "Champions League"),  # should be "normal"
-            ("2024-2025", "Big 5 combined"),  # cuz it's different
+            ("1954-1955", "England Premier League"),  # doesn't have any stat categories data
+            ("2024-2025", "UEFA Champions League"),  # should be "normal"
+            ("2024-2025", "FBref Big 5 Combined"),  # cuz it's different
         ]
     )
     def test_scrape_specific_all_stats(self, year, league):

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -10,7 +10,7 @@ from ScraperFC import Sofascore
 from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
 from ScraperFC.utils import get_module_comps
 
-comps = get_module_comps("Sofascore")
+comps = get_module_comps("SOFASCORE")
 
 match_url = 'https://www.sofascore.com/fc-bayern-munchen-manchester-united/Ksxdb#id:11605966'
 match_id = 11605966

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -1,14 +1,16 @@
-import sys
-sys.path.append('./src/')
-from ScraperFC import Sofascore
-from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
-from ScraperFC.sofascore import comps
-
 import pytest
 from contextlib import nullcontext as does_not_raise
 import random
 import numpy as np
 import pandas as pd
+import sys
+
+sys.path.append('./src/')
+from ScraperFC import Sofascore
+from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
+from ScraperFC.utils import get_module_comps
+
+comps = get_module_comps("Sofascore")
 
 match_url = 'https://www.sofascore.com/fc-bayern-munchen-manchester-united/Ksxdb#id:11605966'
 match_id = 11605966
@@ -48,7 +50,7 @@ class TestSofascore:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('19/20', 'Ligue 1', does_not_raise()),
+        [('19/20', 'France Ligue 1', does_not_raise()),
          ('23/24', 'fake league', pytest.raises(InvalidLeagueException)),
          ('17/18', 2000, pytest.raises(TypeError))]
     )
@@ -66,9 +68,9 @@ class TestSofascore:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('17/18', 'La Liga', does_not_raise()),
-         ('fake year', 'EPL', pytest.raises(InvalidYearException)),
-         (2024, 'EPL', pytest.raises(TypeError))]
+        [('17/18', 'Spain La Liga', does_not_raise()),
+         ('fake year', 'England Premier League', pytest.raises(InvalidYearException)),
+         (2024, 'England Premier League', pytest.raises(TypeError))]
     )
     def test_invalid_years(self, year, league, expected):
         """ Test checks on year input

--- a/test/test_transfermarkt.py
+++ b/test/test_transfermarkt.py
@@ -1,21 +1,23 @@
 import sys
-sys.path.append('./src/')
-from ScraperFC import Transfermarkt
-from ScraperFC.transfermarkt import comps
-from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
 import random
 import pandas as pd
 import pytest
 from contextlib import nullcontext as does_not_raise
+
+sys.path.append('./src/')
+from ScraperFC import Transfermarkt
+from ScraperFC.transfermarkt import comps
+from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
+from ScraperFC.utils import get_module_comps
 
 class TestTransfermarkt:
 
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('23/24', 'EFL2', does_not_raise()),
-         (2024, 'Serie A', pytest.raises(TypeError)),
-         ('fake year', 'Serie B', pytest.raises(InvalidYearException))]
+        [('23/24', 'England EFL League 2', does_not_raise()),
+         (2024, 'Italy Serie A', pytest.raises(TypeError)),
+         ('fake year', 'Italy Serie B', pytest.raises(InvalidYearException))]
     )
     def test_invalid_year(self, year, league, expected):
         tm = Transfermarkt()
@@ -27,7 +29,7 @@ class TestTransfermarkt:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('76/77', 'La Liga', does_not_raise()),
+        [('76/77', 'Spain La Liga', does_not_raise()),
          ('76/77', -1, pytest.raises(TypeError)),
          ('76/77', 'fake league', pytest.raises(InvalidLeagueException))]
     )
@@ -43,7 +45,7 @@ class TestTransfermarkt:
     # ==============================================================================================
     @pytest.mark.parametrize(
         "year, league",
-        [("1901/02", "Jupiler Pro League"),]
+        [("1901/02", "Belgium Pro League"),]
     )
     def test_no_club_links(self, year, league):
         tm = Transfermarkt()

--- a/test/test_transfermarkt.py
+++ b/test/test_transfermarkt.py
@@ -3,12 +3,15 @@ import random
 import pandas as pd
 import pytest
 from contextlib import nullcontext as does_not_raise
+from rootutils import find_root
 
-sys.path.append('./src/')
+sys.path.append(str(find_root() / 'src'))
 from ScraperFC import Transfermarkt
 from ScraperFC.transfermarkt import comps
 from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
 from ScraperFC.utils import get_module_comps
+
+comps = get_module_comps("TRANSFERMARKT")
 
 class TestTransfermarkt:
 

--- a/test/test_understat.py
+++ b/test/test_understat.py
@@ -1,22 +1,25 @@
 import sys
 sys.path.append('./src')
 from ScraperFC import Understat
-from ScraperFC.understat import comps
 from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
+from ScraperFC.utils import get_module_comps
 
 import random
 import pandas as pd
 import pytest
 from contextlib import nullcontext as does_not_raise
 
+comps = get_module_comps("Understat")
+
+
 class TestUnderstat:
 
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('2019/2020', 'Ligue 1', does_not_raise()),
-         (2020, 'Ligue 1', pytest.raises(TypeError)),
-         ('fake year', 'Ligue 1', pytest.raises(InvalidYearException))]
+        [('2019/2020', 'France Ligue 1', does_not_raise()),
+         (2020, 'France Ligue 1', pytest.raises(TypeError)),
+         ('fake year', 'France Ligue 1', pytest.raises(InvalidYearException))]
     )
     def test_invalid_year(self, year, league, expected):
         us = Understat()
@@ -38,8 +41,8 @@ class TestUnderstat:
     # ==============================================================================================
     @pytest.mark.parametrize(
         'year, league, expected',
-        [('2023/2024', 'RFPL', does_not_raise()),
-         ('2023/2024', {'league': 'RFPL'}, pytest.raises(TypeError)),
+        [('2023/2024', 'Russia Premier League', does_not_raise()),
+         ('2023/2024', {'league': 'Russia Premier League'}, pytest.raises(TypeError)),
          ('2023/2024', 'fake league', pytest.raises(InvalidLeagueException))]
     )
     def test_invalid_league(self, year, league, expected):

--- a/test/test_understat.py
+++ b/test/test_understat.py
@@ -1,15 +1,16 @@
 import sys
-sys.path.append('./src')
-from ScraperFC import Understat
-from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
-from ScraperFC.utils import get_module_comps
-
 import random
 import pandas as pd
 import pytest
 from contextlib import nullcontext as does_not_raise
+from rootutils import find_root
 
-comps = get_module_comps("Understat")
+sys.path.append(str(find_root() / 'src'))
+from ScraperFC import Understat
+from ScraperFC.scraperfc_exceptions import InvalidLeagueException, InvalidYearException
+from ScraperFC.utils import get_module_comps
+
+comps = get_module_comps("UNDERSTAT")
 
 
 class TestUnderstat:


### PR DESCRIPTION
# BREAKING CHANGE!

This will be rolled into v4.0.0 release.

This PR moves the config for all competitions into a single file. Previously, each module had its own competitions config dict. Also required changes to source code and tests.

# Why this change?

This enforces a single source of truth for competitions across all modules. Before this, there were several competitions that used different names across different modules. Not desirable. This also makes it very clear what modules can be used for each league, just be looking at the config for that league in that YAML file.

I'm also hoping this makes it easier for users to add leagues and contribute back to the package.

# Standard format

All competition names should be <Country> <Competition Name> for domestic competitions. For international/continental competitions, the name should be <Governing Body> <Competition Name>.

The first layer of keys under the competition should be a module name, in all caps. The second layer of keys needs to be module-specific config options. No rules about case for the second layer of keys at this time.