### PR TITLE
fix: update Transfermarkt scraper to use ceapi JSON endpoints

### DIFF
--- a/src/ScraperFC/transfermarkt.py
+++ b/src/ScraperFC/transfermarkt.py
@@ -9,6 +9,17 @@ from ScraperFC.utils import get_module_comps, botasaurus_request_get_soup
 
 TRANSFERMARKT_ROOT = "https://www.transfermarkt.us"
 
+# Headers for Transfermarkt AJAX / ceapi endpoints.  The site returns JSON for
+# these endpoints only when the request looks like an in-page XHR.
+_TM_AJAX_HEADERS = {
+    "user-agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "accept": "application/json, text/javascript, */*; q=0.01",
+    "X-Requested-With": "XMLHttpRequest",
+}
+
 comps = get_module_comps("TRANSFERMARKT")
 
 
@@ -269,32 +280,61 @@ class Transfermarkt():
         contract_expiration = None if len(contract_expiration) == 0 else contract_expiration[0]  # type: ignore
 
         # Market value history
+        # Transfermarkt moved the chart data out of an inline Highcharts script into a
+        # dedicated JSON endpoint.  We query it directly instead of parsing script tags.
+        player_id = player_link.split("/")[-1]
         try:
-            script = [
-                s for s in soup.find_all("script", {"type": "text/javascript"})
-                if "var chart = new Highcharts.Chart" in str(s)
-            ][0]
-            values = [int(s.split(",")[0]) for s in str(script).split("y\":")[2:-2]]
-            dates = [
-                s.split("datum_mw\":")[-1].split(",\"x")[0].replace("\\x20", " ").replace("\"", "")
-                for s in str(script).split("y\":")[2:-2]
-            ]
-            market_value_history = pd.DataFrame({"date": dates, "value": values})
-        except IndexError:
+            mv_r = requests.get(
+                f"{TRANSFERMARKT_ROOT}/ceapi/marketValueDevelopment/graph/{player_id}",
+                headers=_TM_AJAX_HEADERS,
+            )
+            mv_r.raise_for_status()
+            mv_data = mv_r.json().get("list", [])
+            market_value_history = (
+                pd.DataFrame({
+                    "date": [e["datum_mw"] for e in mv_data],
+                    "value": [e["y"] for e in mv_data],
+                })
+                if mv_data else None
+            )
+        except (requests.HTTPError, ValueError, KeyError):
             market_value_history = None
 
         # Transfer History
-        rows = soup.find_all("div", {"class": "grid tm-player-transfer-history-grid"})
-        transfer_history = pd.DataFrame(
-            data=[[s.strip() for s in row.getText().split("\n\n") if s != ""] for row in rows],
-            columns=["Season", "Date", "Left", "Joined", "MV", "Fee", ""]
-        ).drop(
-            columns=[""]
-        )
+        # Transfer rows are now loaded via XHR rather than being embedded in the HTML.
+        # player_id already extracted above for the market-value call.
+        _TH_COLS = ["Season", "Date", "Left", "Joined", "MV", "Fee"]
+        try:
+            th_r = requests.get(
+                f"{TRANSFERMARKT_ROOT}/ceapi/transferHistory/list/{player_id}",
+                headers=_TM_AJAX_HEADERS,
+            )
+            th_r.raise_for_status()
+            transfers = th_r.json().get("transfers", [])
+            transfer_history = (
+                pd.DataFrame(
+                    data=[
+                        {
+                            "Season": t.get("season", ""),
+                            "Date": t.get("date", ""),
+                            "Left": t.get("from", {}).get("clubName", ""),
+                            "Joined": t.get("to", {}).get("clubName", ""),
+                            "MV": t.get("marketValue", ""),
+                            "Fee": t.get("fee", ""),
+                        }
+                        for t in transfers
+                    ],
+                    columns=_TH_COLS,
+                )
+                if transfers
+                else pd.DataFrame(columns=_TH_COLS)
+            )
+        except (requests.HTTPError, ValueError, KeyError):
+            transfer_history = pd.DataFrame(columns=_TH_COLS)
 
         player = pd.Series(dtype=object)
         player["Name"] = name
-        player["ID"] = player_link.split("/")[-1]
+        player["ID"] = player_id
         player["Value"] = value
         player["Value last updated"] = value_last_updated
         player["DOB"] = dob

--- a/src/ScraperFC/transfermarkt.py
+++ b/src/ScraperFC/transfermarkt.py
@@ -287,6 +287,7 @@ class Transfermarkt():
             mv_r = requests.get(
                 f"{TRANSFERMARKT_ROOT}/ceapi/marketValueDevelopment/graph/{player_id}",
                 headers=_TM_AJAX_HEADERS,
+                timeout=30,
             )
             mv_r.raise_for_status()
             mv_data = mv_r.json().get("list", [])
@@ -308,6 +309,7 @@ class Transfermarkt():
             th_r = requests.get(
                 f"{TRANSFERMARKT_ROOT}/ceapi/transferHistory/list/{player_id}",
                 headers=_TM_AJAX_HEADERS,
+                timeout=30,
             )
             th_r.raise_for_status()
             transfers = th_r.json().get("transfers", [])


### PR DESCRIPTION
Splitting out the Transfermarkt changes from #84 as requested.

## What changed

Two fields in `scrape_player()` were silently broken:

- **`market_value_history`** — was parsed from an inline `var chart = new Highcharts.Chart` script that no longer appears in the initial HTML. Result: always `None`.
- **`transfer_history`** — was parsed from `div.grid.tm-player-transfer-history-grid` which is no longer in the initial HTML. Result: always an empty DataFrame.

Both are now fetched from Transfermarkt's internal ceapi endpoints that serve the same data as JSON:

```
GET /ceapi/marketValueDevelopment/graph/{player_id}   → {"list": [{datum_mw, y, ...}]}
GET /ceapi/transferHistory/list/{player_id}           → {"transfers": [{season, date, from, to, marketValue, fee}]}
```

A module-level `_TM_AJAX_HEADERS` constant sets `X-Requested-With: XMLHttpRequest` and a modern User-Agent — both are required for the ceapi to return JSON rather than an error.

The returned DataFrame schemas are unchanged:
- `market_value_history`: `date` / `value` columns
- `transfer_history`: `Season` / `Date` / `Left` / `Joined` / `MV` / `Fee` columns

Also adds `timeout=30` to both new `requests.get()` calls (flagged HIGH by Codacy — legitimate).

## Verified

Live-tested against Erling Haaland (player ID 418560): returns 26-entry market-value history and 5-row transfer history with correct column names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)