### PR TITLE
Add include_career_stats flag to scrape_player_details

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ exclude_patterns = ["*.ipynb_checkpoints"]
 # Ignore warnings for some types not being found
 nitpick_ignore = [
     ("py:class", "pd.DataFrame"),
+    ("py:class", "pandas.DataFrame"),
     ("py:class", "pandas.core.frame.DataFrame"),
     ("py:class", "optional"),
     ("py:class", "default True"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent"
 ]
 dependencies = [

--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -571,10 +571,10 @@ class Sofascore:
             # Insert team name and ID into series and convert to DataFrame row
             team_row["teamId"] = team_id
             team_row["teamName"] = team["name"]
-            team_row = team_row.to_frame().T
+            team_row_df = team_row.to_frame().T
 
             # Append the team row to the main DataFrame
-            df = pd.concat([df, team_row], axis=0, ignore_index=True)
+            df = pd.concat([df, team_row_df], axis=0, ignore_index=True)
 
         # Reorder columns so that team name and ID are first
         df = pd.concat(

--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -585,7 +585,9 @@ class Sofascore:
         return df
 
     # ==============================================================================================
-    def scrape_player_details(self, year: str, league: str) -> list[SofascorePlayer]:
+    def scrape_player_details(
+        self, year: str, league: str, include_career_stats: bool = True
+    ) -> list[SofascorePlayer]:
         """ Scrape details for all players in a given year and league. Details are things like
         name, DOB, position, heigh, weight, contract expiration, etc.
 
@@ -596,6 +598,10 @@ class Sofascore:
         :type year: str
         :param league: .. include:: ./arg_docstrings/league.rst
         :type league: str
+        :param include_career_stats: If True (default), fetch career statistics for each player
+            via an additional API call. Set to False to skip this call when career stats are not
+            needed, reducing scrape time.
+        :type include_career_stats: bool
         :rtype: list[SofascorePlayer]
         """
         player_ids = self.get_league_player_ids(year, league)
@@ -649,7 +655,9 @@ class Sofascore:
                 if "proposedMarketValueRaw" in player_dict
                 and "currency" in player_dict["proposedMarketValueRaw"] else None
             )
-            career_stats = _get_player_career_stats_df(player_id, API_PREFIX)
+            career_stats = (
+                _get_player_career_stats_df(player_id, API_PREFIX) if include_career_stats else None
+            )
 
             player = SofascorePlayer(
                 id=player_id, name=player_name, team_name=team_name, team_id=team_id,

--- a/src/ScraperFC/sofascore_player.py
+++ b/src/ScraperFC/sofascore_player.py
@@ -18,7 +18,7 @@ class SofascorePlayer:
     contract_until: datetime | None
     market_value: int | None
     market_value_currency: str | None
-    career_stats: pd.DataFrame
+    career_stats: pd.DataFrame | None
 
     def __repr__(self) -> str:
         return f"SofascorePlayer(id={self.id}, name={self.name})"

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -243,3 +243,8 @@ class TestSofascore:
         assert len(player_ids) == len(player_details)
         assert isinstance(player_details, list)
         assert all(isinstance(player, SofascorePlayer) for player in player_details)
+        assert all(isinstance(player.career_stats, pd.DataFrame) for player in player_details)
+
+        player_details_no_stats = ss.scrape_player_details(year, league, include_career_stats=False)
+        assert len(player_ids) == len(player_details_no_stats)
+        assert all(player.career_stats is None for player in player_details_no_stats)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py310, py311, py312, py313
+envlist = py310, py311, py312, py313, py314
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
## Summary

- Adds an optional `include_career_stats: bool = True` parameter to `scrape_player_details` in `sofascore.py`. When set to `False`, the per-player career stats API call is skipped, reducing scrape time when that data isn't needed.
- Updates `SofascorePlayer.career_stats` type annotation from `pd.DataFrame` to `pd.DataFrame | None` to reflect the new possible value.
- Extends `test_scrape_player_details` to assert `career_stats` is a `pd.DataFrame` by default and `None` when `include_career_stats=False`.
- Fixes a pre-existing mypy error in `scrape_team_league_stats` where `team_row` (typed `pd.Series`) was reassigned to a `pd.DataFrame` — renamed to `team_row_df`.
- Adds Python 3.14 to `tox.ini` envlist and `pyproject.toml` classifiers.
- Adds `pandas.DataFrame` to `nitpick_ignore` in `docs/source/conf.py` to fix a sphinx docs build failure caused by the new union type annotation.

## Test plan

All tox environments were run locally and passed:

- [x] `python -m tox -r -e typecheck`
- [x] `python -m tox -r -e lint`
- [x] `python -m tox -r -e docs`
- [x] `python -m tox -r -e build`
- [x] `python -m tox -r -e py314` (full test suite against live Sofascore API)