### PR TITLE
fix(sofascore): bypass anti-bot challenge via warm-session XHR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 # -- Metadata --------------------------------------------------------------------------------------
 name = "ScraperFC"
-version = "4.5.0"
+version = "4.5.1"
 description = "Package for scraping soccer data from a variety of sources."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.package-data]
 "ScraperFC" = ["comps.yaml"]
 
+# -- Security linting ------------------------------------------------------------------------------
+[tool.bandit]
+exclude_dirs = ["test"]
+skips = ["B101"]
+
 # -- Typechecking ----------------------------------------------------------------------------------
 [tool.mypy]
 ignore_missing_imports = true

--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 from datetime import datetime, timezone, timedelta
 
 from .scraperfc_exceptions import InvalidLeagueException, InvalidYearException
-from .utils import botasaurus_browser_get_json, get_module_comps
+from .utils import botasaurus_browser_get_json_via_xhr, get_module_comps
 from .sofascore_player import SofascorePlayer
 from .sofascore_helpers import _get_player_career_stats_df
 
@@ -23,6 +23,7 @@ from .sofascore_helpers import _get_player_career_stats_df
 """
 
 API_PREFIX = "https://api.sofascore.com/api/v1"
+_SOFASCORE_HOME = "https://www.sofascore.com/"
 
 comps = get_module_comps("SOFASCORE")
 
@@ -97,7 +98,7 @@ class Sofascore:
             raise InvalidLeagueException(league, "Sofascore", list(comps.keys()))
 
         url = f"{API_PREFIX}/unique-tournament/{comps[league]['SOFASCORE']}/seasons/"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
         seasons = {x["year"]: x["id"] for x in response["seasons"]}
         return seasons
 
@@ -123,9 +124,10 @@ class Sofascore:
         matches = list()
         i = 0
         while 1:
-            response = botasaurus_browser_get_json(
+            response = botasaurus_browser_get_json_via_xhr(
                 f"{API_PREFIX}/unique-tournament/{comps[league]['SOFASCORE']}/"
-                f"season/{valid_seasons[year]}/events/last/{i}"
+                f"season/{valid_seasons[year]}/events/last/{i}",
+                _SOFASCORE_HOME,
             )
             if "events" not in response:
                 break
@@ -173,7 +175,7 @@ class Sofascore:
         :rtype: dict
         """
         match_id = self._check_and_convert_match_id(match_id)
-        response = botasaurus_browser_get_json(f"{API_PREFIX}/event/{match_id}")
+        response = botasaurus_browser_get_json_via_xhr(f"{API_PREFIX}/event/{match_id}", _SOFASCORE_HOME)
         data = response["event"]
         return data
 
@@ -225,7 +227,7 @@ class Sofascore:
         """
         match_id = self._check_and_convert_match_id(match_id)
         url = f"{API_PREFIX}/event/{match_id}/lineups"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
 
         if "error" not in response:
             teams = ["home", "away"]
@@ -263,7 +265,7 @@ class Sofascore:
             raise InvalidYearException(year, league, list(valid_seasons.keys()))
 
         url = f"{API_PREFIX}/unique-tournament/{comps[league]['SOFASCORE']}/season/{valid_seasons[year]}/players"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
         player_ids = [x["playerId"] for x in response["players"]]
 
         return player_ids
@@ -317,7 +319,7 @@ class Sofascore:
                 f"&accumulation={accumulation}" +\
                 f"&fields={self.concatenated_stat_names}" +\
                 f"&filters=position.in.{positions}"
-            response = botasaurus_browser_get_json(request_url)
+            response = botasaurus_browser_get_json_via_xhr(request_url, _SOFASCORE_HOME)
             results += response["results"]
             if (response["page"] == response["pages"]) or (response["pages"] == 0):
                 break
@@ -348,7 +350,7 @@ class Sofascore:
         """
         match_id = self._check_and_convert_match_id(match_id)
         url = f"{API_PREFIX}/event/{match_id}/graph"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
 
         if "error" not in response:
             match_momentum_df = pd.DataFrame(response["graphPoints"])
@@ -371,7 +373,7 @@ class Sofascore:
         """
         match_id = self._check_and_convert_match_id(match_id)
         url = f"{API_PREFIX}/event/{match_id}/statistics"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
 
         if "error" not in response:
             df = pd.DataFrame()
@@ -403,7 +405,7 @@ class Sofascore:
         match_id = self._check_and_convert_match_id(match_id)
         match_dict = self.get_match_dict(match_id)  # used to get home and away team names and IDs
         url = f"{API_PREFIX}/event/{match_id}/lineups"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
 
         if "error" not in response:
             home_players = response["home"]["players"]
@@ -448,7 +450,7 @@ class Sofascore:
         match_id = self._check_and_convert_match_id(match_id)
         home_name, away_name = self.get_team_names(match_id)
         url = f"{API_PREFIX}/event/{match_id}/average-positions"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
 
         if "error" not in response:
             df = pd.DataFrame()
@@ -487,7 +489,7 @@ class Sofascore:
             player_id = players[player]
             url = f"{API_PREFIX}/event/{match_id}/player/{player_id}/heatmap"
 
-            response = botasaurus_browser_get_json(url)
+            response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
 
             if "error" not in response:
                 heatmap = [(z["x"], z["y"]) for z in response["heatmap"]]
@@ -510,7 +512,7 @@ class Sofascore:
         """
         match_id = self._check_and_convert_match_id(match_id)
         url = f"{API_PREFIX}/event/{match_id}/shotmap"
-        response = botasaurus_browser_get_json(url)
+        response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
         if "error" not in response:
             df = pd.DataFrame.from_dict(response["shotmap"])
         else:
@@ -546,8 +548,9 @@ class Sofascore:
         year_id = valid_seasons[year]
 
         # Find all teams in the league that season
-        teams_list = botasaurus_browser_get_json(
-            f"{API_PREFIX}/unique-tournament/{league_id}/season/{year_id}/teams"
+        teams_list = botasaurus_browser_get_json_via_xhr(
+            f"{API_PREFIX}/unique-tournament/{league_id}/season/{year_id}/teams",
+            _SOFASCORE_HOME,
         )["teams"]
 
         # Iterate over teams and build dataframe of stats
@@ -555,9 +558,10 @@ class Sofascore:
         for team in (pbar := tqdm(teams_list, ncols=100)):
             team_id = team["id"]
             pbar.set_description(f"{year} {league}, team ID {team_id}")
-            result = botasaurus_browser_get_json(
+            result = botasaurus_browser_get_json_via_xhr(
                 f"{API_PREFIX}/team/{team_id}/unique-tournament/{league_id}/season/{year_id}/"
-                "statistics/overall"
+                "statistics/overall",
+                _SOFASCORE_HOME,
             )
 
             if "statistics" in result:
@@ -608,7 +612,7 @@ class Sofascore:
             pbar.set_description(f"{year} {league}, player ID {player_id}")
 
             url = f"{API_PREFIX}/player/{player_id}"
-            response = botasaurus_browser_get_json(url)
+            response = botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)
             player_dict = response["player"]
 
             player_name = player_dict["name"]

--- a/src/ScraperFC/sofascore.py
+++ b/src/ScraperFC/sofascore.py
@@ -175,7 +175,9 @@ class Sofascore:
         :rtype: dict
         """
         match_id = self._check_and_convert_match_id(match_id)
-        response = botasaurus_browser_get_json_via_xhr(f"{API_PREFIX}/event/{match_id}", _SOFASCORE_HOME)
+        response = botasaurus_browser_get_json_via_xhr(
+            f"{API_PREFIX}/event/{match_id}", _SOFASCORE_HOME
+        )
         data = response["event"]
         return data
 

--- a/src/ScraperFC/sofascore_helpers.py
+++ b/src/ScraperFC/sofascore_helpers.py
@@ -1,12 +1,15 @@
 import pandas as pd
-from .utils.botasaurus_getters import botasaurus_browser_get_json
+from .utils.botasaurus_getters import botasaurus_browser_get_json_via_xhr
 
 # ==================================================================================================
 def _get_player_career_stats_df(player_id: int, api_prefix: str) -> pd.DataFrame:
     if not isinstance(player_id, int):
         raise TypeError("player_id must be an integer.")
 
-    response = botasaurus_browser_get_json(f"{api_prefix}/player/{player_id}/statistics")
+    response = botasaurus_browser_get_json_via_xhr(
+        f"{api_prefix}/player/{player_id}/statistics",
+        "https://www.sofascore.com/",
+    )
 
     if "seasons" not in response:
         return pd.DataFrame()

--- a/src/ScraperFC/utils/__init__.py
+++ b/src/ScraperFC/utils/__init__.py
@@ -1,11 +1,12 @@
 __all__ = [
     "get_proxy", "xpath_soup", "botasaurus_request_get_json", "botasaurus_browser_get_json",
+    "botasaurus_browser_get_json_via_xhr",
     "botasaurus_request_get_soup", "botasaurus_browser_get_soup", "load_comps", "get_module_comps",
 ]
 
 from .get_proxy import get_proxy
 from .xpath_soup import xpath_soup
 from .botasaurus_getters import botasaurus_request_get_json, botasaurus_browser_get_json,\
-    botasaurus_request_get_soup, botasaurus_browser_get_soup
+    botasaurus_browser_get_json_via_xhr, botasaurus_request_get_soup, botasaurus_browser_get_soup
 from .load_comps import load_comps
 from .get_module_comps import get_module_comps

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -44,7 +44,8 @@ def _validate_browser_get_json_args(
         wait_for_complete_page_load: bool, delay: int,
         via_xhr: bool, warm_url: str | None, add_arguments: list[str] | None,
 ) -> None:
-    """Validate arguments for :func:`botasaurus_browser_get_json`.
+    """
+    Validate arguments for :func:`botasaurus_browser_get_json`.
 
     :raises TypeError: If any argument is the wrong type.
     :raises ValueError: If ``delay`` is negative, or ``via_xhr=True`` without ``warm_url``.
@@ -78,7 +79,8 @@ def botasaurus_browser_get_json(
         via_xhr: bool = False, warm_url: str | None = None,
         add_arguments: list[str] | None = None,
 ) -> dict:
-    """Use Botasaurus BROWSER module to get JSON from a page.
+    """
+    Use Botasaurus BROWSER module to get JSON from a page.
 
     Two modes:
 
@@ -155,7 +157,8 @@ def botasaurus_browser_get_json_via_xhr(
         block_images_and_css: bool = True,
         add_arguments: list[str] | None = None,
 ) -> dict:
-    """Fetch a JSON API endpoint that sits behind a browser/bot challenge.
+    """
+    Fetch a JSON API endpoint that sits behind a browser/bot challenge.
 
     Warms a browser session on ``warm_url`` then issues an in-page XHR to ``url``.
     Generic: any challenge-blocked source can use it by passing its own origin as

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -37,23 +37,42 @@ def botasaurus_request_get_json(url: str, delay: int = 0) -> dict:
 # ==================================================================================================
 def botasaurus_browser_get_json(
         url: str, headless: bool = True, block_images_and_css: bool = True,
-        wait_for_complete_page_load: bool = True, delay: int = 0
+        wait_for_complete_page_load: bool = True, delay: int = 0,
+        via_xhr: bool = False, warm_url: str | None = None,
 ) -> dict:
-    """Use Botasaurus BROWSER module to get JSON from page
+    """Use Botasaurus BROWSER module to get JSON from a page.
 
-    :param url: The URL to scrape
+    Two modes:
+
+    * **Direct navigation** (default): navigate to ``url`` and parse the page text
+      as JSON.
+    * **In-page XHR** (``via_xhr=True``): navigate to ``warm_url`` first to
+      establish a session and pass any anti-bot challenge, then issue a
+      synchronous ``XMLHttpRequest`` to ``url`` from that page, sending the
+      ``X-Requested-With: XMLHttpRequest`` header that single-page-app backends
+      expect. ``warm_url`` is required in this mode and ``headless`` must be
+      ``False`` for the challenge to resolve. ``delay`` is the post-warm-up wait.
+
+    :param url: The URL to scrape.
     :type url: str
-    :param headless: Whether to run the browser in headless mode
+    :param headless: Whether to run the browser in headless mode.
     :type headless: bool
-    :param block_images_and_css: Whether to block images and CSS
+    :param block_images_and_css: Whether to block images and CSS.
     :type block_images_and_css: bool
-    :param wait_for_complete_page_load: Whether to wait for the page to load completely
+    :param wait_for_complete_page_load: Whether to wait for the page to load completely.
     :type wait_for_complete_page_load: bool
-    :param delay: Seconds to wait after the request (default: 0)
+    :param delay: Seconds to wait after navigation (default: 0). In ``via_xhr``
+        mode this is the wait between loading ``warm_url`` and issuing the XHR.
     :type delay: int
-    :raises TypeError: If any of the parameters are the wrong type
-    :raises ValueError: If ``delay`` is negative
-    :return: JSON data
+    :param via_xhr: Fetch ``url`` as an in-page XHR from ``warm_url`` instead of
+        navigating to it directly.
+    :type via_xhr: bool
+    :param warm_url: Origin page to load before the XHR. Required when
+        ``via_xhr=True``; ignored otherwise.
+    :type warm_url: str | None
+    :raises TypeError: If any of the parameters are the wrong type.
+    :raises ValueError: If ``delay`` is negative, or ``via_xhr=True`` without ``warm_url``.
+    :return: JSON data.
     :rtype: dict
     """
     if not isinstance(url, str):
@@ -68,19 +87,67 @@ def botasaurus_browser_get_json(
         raise TypeError("`delay` must be an int.")
     if delay < 0:
         raise ValueError("`delay` must be non-negative.")
+    if not isinstance(via_xhr, bool):
+        raise TypeError("`via_xhr` must be a bool.")
+    if warm_url is not None and not isinstance(warm_url, str):
+        raise TypeError("`warm_url` must be a string or None.")
+    if via_xhr and warm_url is None:
+        raise ValueError("`warm_url` is required when `via_xhr=True`.")
 
     @browser(
         headless=headless, block_images_and_css=block_images_and_css,
         wait_for_complete_page_load=wait_for_complete_page_load,
         output=None, create_error_logs=False
     )
-    def _get_json(driver, url):  # type: ignore
-        driver.get(url)
+    def _get_json(driver, data):  # type: ignore
+        target = data["url"]
+        if data["via_xhr"]:
+            driver.get(data["warm_url"])    # load origin page to set session cookies
+            if delay > 0:
+                time.sleep(delay)           # wait for the challenge to resolve
+            js = f"""
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', {json.dumps(target)}, false);
+            xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+            xhr.send();
+            return JSON.parse(xhr.responseText);
+            """
+            return driver.run_js(js)
+        driver.get(target)
         if delay > 0:
             time.sleep(delay)
         return json.loads(driver.page_text)
 
-    return _get_json(url)
+    return _get_json({"url": url, "warm_url": warm_url, "via_xhr": via_xhr})
+
+# ==================================================================================================
+def botasaurus_browser_get_json_via_xhr(
+        url: str, warm_url: str, headless: bool = False, delay: int = 6,
+        block_images_and_css: bool = True,
+) -> dict:
+    """Fetch a JSON API endpoint that sits behind a browser/bot challenge.
+
+    Warms a browser session on ``warm_url`` then issues an in-page XHR to ``url``.
+    Generic: any challenge-blocked source can use it by passing its own origin as
+    ``warm_url`` (e.g. ``"https://fbref.com/"``).
+
+    :param url: API endpoint to fetch.
+    :type url: str
+    :param warm_url: Origin page to load first to acquire session cookies.
+    :type warm_url: str
+    :param headless: Must be ``False`` for the challenge to resolve (default: False).
+    :type headless: bool
+    :param delay: Seconds to wait after warming before the XHR (default: 6).
+    :type delay: int
+    :param block_images_and_css: Whether to block images and CSS.
+    :type block_images_and_css: bool
+    :return: JSON data.
+    :rtype: dict
+    """
+    return botasaurus_browser_get_json(
+        url, via_xhr=True, warm_url=warm_url,
+        headless=headless, delay=delay, block_images_and_css=block_images_and_css,
+    )
 
 # ==================================================================================================
 def botasaurus_request_get_soup(url: str, delay: int = 0) -> BeautifulSoup:

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -39,6 +39,34 @@ def botasaurus_request_get_json(url: str, delay: int = 0) -> dict:
     return _get_json(url)
 
 # ==================================================================================================
+def _validate_browser_get_json_args(
+        url: str, headless: bool, block_images_and_css: bool,
+        wait_for_complete_page_load: bool, delay: int,
+        via_xhr: bool, warm_url: str | None, add_arguments: list[str] | None,
+) -> None:
+    if not isinstance(url, str):
+        raise TypeError("`url` must be a string.")
+    if not isinstance(headless, bool):
+        raise TypeError("`headless` must be a bool.")
+    if not isinstance(block_images_and_css, bool):
+        raise TypeError("`block_images_and_css` must be a bool.")
+    if not isinstance(wait_for_complete_page_load, bool):
+        raise TypeError("`wait_for_complete_page_load` must be a bool.")
+    if not isinstance(delay, int):
+        raise TypeError("`delay` must be an int.")
+    if delay < 0:
+        raise ValueError("`delay` must be non-negative.")
+    if not isinstance(via_xhr, bool):
+        raise TypeError("`via_xhr` must be a bool.")
+    if warm_url is not None and not isinstance(warm_url, str):
+        raise TypeError("`warm_url` must be a string or None.")
+    if via_xhr and warm_url is None:
+        raise ValueError("`warm_url` is required when `via_xhr=True`.")
+    if add_arguments is not None and not isinstance(add_arguments, list):
+        raise TypeError("`add_arguments` must be a list of strings or None.")
+
+
+# ==================================================================================================
 def botasaurus_browser_get_json(
         url: str, headless: bool = True, block_images_and_css: bool = True,
         wait_for_complete_page_load: bool = True, delay: int = 0,
@@ -80,26 +108,10 @@ def botasaurus_browser_get_json(
     :return: JSON data.
     :rtype: dict
     """
-    if not isinstance(url, str):
-        raise TypeError("`url` must be a string.")
-    if not isinstance(headless, bool):
-        raise TypeError("`headless` must be a bool.")
-    if not isinstance(block_images_and_css, bool):
-        raise TypeError("`block_images_and_css` must be a bool.")
-    if not isinstance(wait_for_complete_page_load, bool):
-        raise TypeError("`wait_for_complete_page_load` must be a bool.")
-    if not isinstance(delay, int):
-        raise TypeError("`delay` must be an int.")
-    if delay < 0:
-        raise ValueError("`delay` must be non-negative.")
-    if not isinstance(via_xhr, bool):
-        raise TypeError("`via_xhr` must be a bool.")
-    if warm_url is not None and not isinstance(warm_url, str):
-        raise TypeError("`warm_url` must be a string or None.")
-    if via_xhr and warm_url is None:
-        raise ValueError("`warm_url` is required when `via_xhr=True`.")
-    if add_arguments is not None and not isinstance(add_arguments, list):
-        raise TypeError("`add_arguments` must be a list of strings or None.")
+    _validate_browser_get_json_args(
+        url, headless, block_images_and_css, wait_for_complete_page_load,
+        delay, via_xhr, warm_url, add_arguments,
+    )
 
     _browser_kwargs: dict = dict(
         headless=headless, block_images_and_css=block_images_and_css,
@@ -111,6 +123,7 @@ def botasaurus_browser_get_json(
 
     @browser(**_browser_kwargs)
     def _get_json(driver, data):  # type: ignore
+        """Fetch JSON from ``data['url']``, optionally via warm-session XHR."""
         target = data["url"]
         if data["via_xhr"]:
             driver.get(data["warm_url"])    # load origin page to set session cookies
@@ -130,6 +143,7 @@ def botasaurus_browser_get_json(
         return json.loads(driver.page_text)
 
     return _get_json({"url": url, "warm_url": warm_url, "via_xhr": via_xhr})
+
 
 # ==================================================================================================
 def botasaurus_browser_get_json_via_xhr(

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -127,13 +127,12 @@ def botasaurus_browser_get_json(
         _browser_kwargs["add_arguments"] = add_arguments
 
     @browser(**_browser_kwargs)
-    def _get_json(driver, data):  # type: ignore
-        """Fetch JSON from ``data['url']``, optionally via warm-session XHR."""
-        target = data["url"]
-        if data["via_xhr"]:
-            driver.get(data["warm_url"])    # load origin page to set session cookies
+    def _get_json(driver, target):  # type: ignore
+        """Fetch JSON from ``target``, optionally via warm-session XHR."""
+        if via_xhr:
+            driver.get(warm_url)    # load origin page to set session cookies
             if delay > 0:
-                time.sleep(delay)           # wait for the challenge to resolve
+                time.sleep(delay)   # wait for the challenge to resolve
             js = f"""
             var xhr = new XMLHttpRequest();
             xhr.open('GET', {json.dumps(target)}, false);
@@ -147,7 +146,7 @@ def botasaurus_browser_get_json(
             time.sleep(delay)
         return json.loads(driver.page_text)
 
-    return _get_json({"url": url, "warm_url": warm_url, "via_xhr": via_xhr})  # type: ignore[call-arg]
+    return _get_json(url)
 
 
 # ==================================================================================================

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -44,6 +44,11 @@ def _validate_browser_get_json_args(
         wait_for_complete_page_load: bool, delay: int,
         via_xhr: bool, warm_url: str | None, add_arguments: list[str] | None,
 ) -> None:
+    """Validate arguments for :func:`botasaurus_browser_get_json`.
+
+    :raises TypeError: If any argument is the wrong type.
+    :raises ValueError: If ``delay`` is negative, or ``via_xhr=True`` without ``warm_url``.
+    """
     if not isinstance(url, str):
         raise TypeError("`url` must be a string.")
     if not isinstance(headless, bool):

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -122,7 +122,7 @@ def botasaurus_browser_get_json(
 
 # ==================================================================================================
 def botasaurus_browser_get_json_via_xhr(
-        url: str, warm_url: str, headless: bool = False, delay: int = 6,
+        url: str, warm_url: str, headless: bool = True, delay: int = 6,
         block_images_and_css: bool = True,
 ) -> dict:
     """Fetch a JSON API endpoint that sits behind a browser/bot challenge.
@@ -131,15 +131,19 @@ def botasaurus_browser_get_json_via_xhr(
     Generic: any challenge-blocked source can use it by passing its own origin as
     ``warm_url`` (e.g. ``"https://fbref.com/"``).
 
+    ``block_images_and_css=True`` (the default) is recommended: it reduces page-load
+    time during the warm-up, allowing the challenge to resolve before the browser
+    times out.
+
     :param url: API endpoint to fetch.
     :type url: str
     :param warm_url: Origin page to load first to acquire session cookies.
     :type warm_url: str
-    :param headless: Must be ``False`` for the challenge to resolve (default: False).
+    :param headless: Whether to run the browser in headless mode (default: True).
     :type headless: bool
     :param delay: Seconds to wait after warming before the XHR (default: 6).
     :type delay: int
-    :param block_images_and_css: Whether to block images and CSS.
+    :param block_images_and_css: Whether to block images and CSS (default: True).
     :type block_images_and_css: bool
     :return: JSON data.
     :rtype: dict

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -147,7 +147,7 @@ def botasaurus_browser_get_json(
             time.sleep(delay)
         return json.loads(driver.page_text)
 
-    return _get_json({"url": url, "warm_url": warm_url, "via_xhr": via_xhr})
+    return _get_json({"url": url, "warm_url": warm_url, "via_xhr": via_xhr})  # type: ignore[call-arg]
 
 
 # ==================================================================================================

--- a/src/ScraperFC/utils/botasaurus_getters.py
+++ b/src/ScraperFC/utils/botasaurus_getters.py
@@ -1,8 +1,12 @@
 from botasaurus.request import request
 from botasaurus.browser import browser
 import json
+import sys
 from bs4 import BeautifulSoup
 import time
+
+# Chrome flags required when running as root (e.g. inside a Docker container on Linux)
+_LINUX_CHROME_ARGS = ["--no-sandbox", "--disable-dev-shm-usage"]
 
 
 # ==================================================================================================
@@ -39,6 +43,7 @@ def botasaurus_browser_get_json(
         url: str, headless: bool = True, block_images_and_css: bool = True,
         wait_for_complete_page_load: bool = True, delay: int = 0,
         via_xhr: bool = False, warm_url: str | None = None,
+        add_arguments: list[str] | None = None,
 ) -> dict:
     """Use Botasaurus BROWSER module to get JSON from a page.
 
@@ -93,12 +98,18 @@ def botasaurus_browser_get_json(
         raise TypeError("`warm_url` must be a string or None.")
     if via_xhr and warm_url is None:
         raise ValueError("`warm_url` is required when `via_xhr=True`.")
+    if add_arguments is not None and not isinstance(add_arguments, list):
+        raise TypeError("`add_arguments` must be a list of strings or None.")
 
-    @browser(
+    _browser_kwargs: dict = dict(
         headless=headless, block_images_and_css=block_images_and_css,
         wait_for_complete_page_load=wait_for_complete_page_load,
-        output=None, create_error_logs=False
+        output=None, create_error_logs=False,
     )
+    if add_arguments:
+        _browser_kwargs["add_arguments"] = add_arguments
+
+    @browser(**_browser_kwargs)
     def _get_json(driver, data):  # type: ignore
         target = data["url"]
         if data["via_xhr"]:
@@ -124,6 +135,7 @@ def botasaurus_browser_get_json(
 def botasaurus_browser_get_json_via_xhr(
         url: str, warm_url: str, headless: bool = True, delay: int = 6,
         block_images_and_css: bool = True,
+        add_arguments: list[str] | None = None,
 ) -> dict:
     """Fetch a JSON API endpoint that sits behind a browser/bot challenge.
 
@@ -135,6 +147,9 @@ def botasaurus_browser_get_json_via_xhr(
     time during the warm-up, allowing the challenge to resolve before the browser
     times out.
 
+    On Linux (e.g. inside a Docker container), ``--no-sandbox`` and
+    ``--disable-dev-shm-usage`` are added automatically so Chrome can run as root.
+
     :param url: API endpoint to fetch.
     :type url: str
     :param warm_url: Origin page to load first to acquire session cookies.
@@ -145,12 +160,20 @@ def botasaurus_browser_get_json_via_xhr(
     :type delay: int
     :param block_images_and_css: Whether to block images and CSS (default: True).
     :type block_images_and_css: bool
+    :param add_arguments: Extra Chrome command-line flags (default: None).
+    :type add_arguments: list[str] | None
     :return: JSON data.
     :rtype: dict
     """
+    args = list(add_arguments) if add_arguments else []
+    if sys.platform == "linux":
+        for flag in _LINUX_CHROME_ARGS:
+            if flag not in args:
+                args.append(flag)
     return botasaurus_browser_get_json(
         url, via_xhr=True, warm_url=warm_url,
         headless=headless, delay=delay, block_images_and_css=block_images_and_css,
+        add_arguments=args or None,
     )
 
 # ==================================================================================================

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -243,3 +243,44 @@ class TestSofascore:
         assert len(player_ids) == len(player_details)
         assert isinstance(player_details, list)
         assert all(isinstance(player, SofascorePlayer) for player in player_details)
+
+
+from ScraperFC.utils import (
+    botasaurus_browser_get_json, botasaurus_browser_get_json_via_xhr,
+)
+
+
+class TestViaXhrMode:
+
+    def test_via_xhr_type_error(self):
+        """via_xhr must be a bool."""
+        with pytest.raises(TypeError, match="`via_xhr` must be a bool"):
+            botasaurus_browser_get_json(
+                "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
+                via_xhr="yes",
+            )
+
+    def test_warm_url_type_error(self):
+        """warm_url must be a string or None."""
+        with pytest.raises(TypeError, match="`warm_url` must be a string or None"):
+            botasaurus_browser_get_json(
+                "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
+                warm_url=123,
+            )
+
+    def test_via_xhr_requires_warm_url(self):
+        """via_xhr=True without warm_url raises ValueError."""
+        with pytest.raises(ValueError, match="`warm_url` is required"):
+            botasaurus_browser_get_json(
+                "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
+                via_xhr=True,
+            )
+
+    def test_via_xhr_helper_returns_data(self):
+        """The convenience helper returns valid Sofascore seasons data."""
+        result = botasaurus_browser_get_json_via_xhr(
+            "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
+            warm_url="https://www.sofascore.com/",
+        )
+        assert "seasons" in result
+        assert len(result["seasons"]) > 0

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -251,8 +251,10 @@ from ScraperFC.utils import (
 
 
 class TestViaXhrMode:
+    """Tests for the via_xhr mode and warm-session XHR helper."""
 
-    def test_via_xhr_type_error(self):
+    @staticmethod
+    def test_via_xhr_type_error():
         """via_xhr must be a bool."""
         with pytest.raises(TypeError, match="`via_xhr` must be a bool"):
             botasaurus_browser_get_json(
@@ -260,7 +262,8 @@ class TestViaXhrMode:
                 via_xhr="yes",
             )
 
-    def test_warm_url_type_error(self):
+    @staticmethod
+    def test_warm_url_type_error():
         """warm_url must be a string or None."""
         with pytest.raises(TypeError, match="`warm_url` must be a string or None"):
             botasaurus_browser_get_json(
@@ -268,7 +271,8 @@ class TestViaXhrMode:
                 warm_url=123,
             )
 
-    def test_via_xhr_requires_warm_url(self):
+    @staticmethod
+    def test_via_xhr_requires_warm_url():
         """via_xhr=True without warm_url raises ValueError."""
         with pytest.raises(ValueError, match="`warm_url` is required"):
             botasaurus_browser_get_json(
@@ -276,7 +280,8 @@ class TestViaXhrMode:
                 via_xhr=True,
             )
 
-    def test_via_xhr_helper_returns_data(self):
+    @staticmethod
+    def test_via_xhr_helper_returns_data():
         """The convenience helper returns valid Sofascore seasons data (headless)."""
         result = botasaurus_browser_get_json_via_xhr(
             "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -287,5 +287,5 @@ class TestViaXhrMode:
             "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
             warm_url="https://www.sofascore.com/",
         )
-        assert "seasons" in result  # noqa: S101
-        assert len(result["seasons"]) > 0  # noqa: S101
+        assert "seasons" in result
+        assert len(result["seasons"]) > 0

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -287,5 +287,5 @@ class TestViaXhrMode:
             "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
             warm_url="https://www.sofascore.com/",
         )
-        assert "seasons" in result
-        assert len(result["seasons"]) > 0
+        assert "seasons" in result  # noqa: S101
+        assert len(result["seasons"]) > 0  # noqa: S101

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -277,7 +277,7 @@ class TestViaXhrMode:
             )
 
     def test_via_xhr_helper_returns_data(self):
-        """The convenience helper returns valid Sofascore seasons data."""
+        """The convenience helper returns valid Sofascore seasons data (headless)."""
         result = botasaurus_browser_get_json_via_xhr(
             "https://api.sofascore.com/api/v1/unique-tournament/17/seasons",
             warm_url="https://www.sofascore.com/",

--- a/test/test_sofascore.py
+++ b/test/test_sofascore.py
@@ -251,6 +251,7 @@ from ScraperFC.utils import (
 
 
 class TestViaXhrMode:
+
     """Tests for the via_xhr mode and warm-session XHR helper."""
 
     @staticmethod


### PR DESCRIPTION
Fixes #93

## Problem

Sofascore's API endpoints return `{'error': {'code': 403, 'reason': 'challenge'}}` when fetched with a fresh browser session. The challenge requires a browser to first visit the Sofascore origin page to establish session cookies, then fetch the API via XHR with the `X-Requested-With: XMLHttpRequest` header.

## Solution

### New generic utility: `botasaurus_browser_get_json_via_xhr`

Added to `ScraperFC/utils/botasaurus_getters.py` and exported from `utils/__init__.py`:

```python
def botasaurus_browser_get_json_via_xhr(
    url: str, warm_url: str, headless: bool = True, delay: int = 6,
    block_images_and_css: bool = True,
    add_arguments: list[str] | None = None,
) -> dict:
```

- Loads `warm_url` first (the origin, e.g. `https://www.sofascore.com/`) to acquire session cookies and pass the challenge
- After `delay` seconds, issues a synchronous in-page XHR to `url` with `X-Requested-With: XMLHttpRequest`
- `block_images_and_css=True` (default) is key: blocking resources reduces page-load time so the challenge resolves before the browser times out
- On Linux, `--no-sandbox` and `--disable-dev-shm-usage` are auto-injected so Chrome works inside Docker containers (running as root)
- Generic by design — any future source behind a similar challenge can reuse this helper

Also extended `botasaurus_browser_get_json` with `via_xhr` / `warm_url` / `add_arguments` params that back the above helper.

### Sofascore call sites updated

All 15 API calls in `sofascore.py` and the single call in `sofascore_helpers.py` now use `botasaurus_browser_get_json_via_xhr(url, _SOFASCORE_HOME)`.

## Testing

- Unit tests for input validation (TypeError / ValueError) in `test/test_sofascore.py` (`TestViaXhrMode`)
- Integration test confirms a live Sofascore call returns data with `"seasons"` key
- Verified `headless=True, block_images_and_css=True` resolves the challenge (headless mode works)